### PR TITLE
Add support for HP Deskjet 3520

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "cwd": "${workspaceRoot}",
+            "runtimeArgs": ["-r", "ts-node/register"],
+            "args": ["${workspaceRoot}/src/index.ts"]
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -4,8 +4,23 @@
 
 Little command line program that allow to send scan from device to computer.
 
-Developed and tested for `Officejet 6500 E710n-z [B21113]` (HP Officejet 6500A Plus)
+Developed and tested for the following HP All-in-One Printers:
+- HP Officejet 6500A Plus
+- HP Deskjet 3520
 
-For this purpose, the original HP Windows application's interaction with the device has been [reverse engineered](protocol_doc/index.md)
+There are good chances it also works on your HP All-in-One Printer.
+For this purpose, the original HP Windows application's interaction with the device has been [reverse engineered](protocol_doc/index.md).
 
 This project is not endorsed by nor affiliated with HP.
+
+## Usage
+```
+git clone ...
+cd node-hp-scan-to
+yarn install -d
+# now edit src/index.ts and set your printer in line "service.name.startsWith("Officejet 6500 E710n-z")"
+ts-node src/index.ts
+```
+
+## Debugging
+I'm using Visual Studio Code to debug this application, so instead of running ts-node just enter `code .` and press F5 to start debugging.

--- a/protocol_doc/index.md
+++ b/protocol_doc/index.md
@@ -1,14 +1,14 @@
 <!-- TOC -->
 
-- [Protocol]downgraded)
+- [Protocol](downgraded)
     - [Recorded Sequence](#recorded-sequence)
+		- [`GET /WalkupScanToComp/WalkupScanToCompCaps`](#get-walkupscantocompwalkupscantocompcaps)
         - [`GET /WalkupScan/WalkupScanDestinations`](#get-walkupscanwalkupscandestinations)
         - [`POST /WalkupScan/WalkupScanDestinations`](#post-walkupscanwalkupscandestinations)
         - [`GET /EventMgmt/EventTable`](#get-eventmgmteventtable)
         - [`GET /EventMgmt/EventTable?timeout=1200`](#get-eventmgmteventtabletimeout1200)
         - [`GET /WalkupScan/WalkupScanDestinations/1cb3125d-7bde-1f09-8da2-2c768ab21113`](#get-walkupscanwalkupscandestinations1cb3125d-7bde-1f09-8da2-2c768ab21113)
         - [`GET /DevMgmt/DiscoveryTree.xml`](#get-devmgmtdiscoverytreexml)
-        - [`GET /WalkupScanToComp/WalkupScanToCompCaps`](#get-walkupscantocompwalkupscantocompcaps)
         - [`GET /Scan/ScanCaps.xml`](#get-scanscancapsxml)
         - [`GET /Scan/Status`](#get-scanstatus)
         - [`GET /WalkupScan/WalkupScanDestinations`](#get-walkupscanwalkupscandestinations-1)
@@ -42,6 +42,48 @@ A single sheet was prepared in the tray. The `scan to computer` has never been a
 
 Rapidly after launching the desktop application a `Scan to PDF` was triggered from the printer's screen.
 
+### `GET /WalkupScanToComp/WalkupScanToCompCaps`
+
+This examines if the further API calls have to use the API WalkupScan or WalkupScanToComp.
+If a HTTP 404 is received, only WalkUpScan can be used.
+If a HTTP 200 is received, only WalkUpScanToComp can be used. In this mode basically in all URLs and XML contents the text 'WalkupScan' has to be replaced with 'WalkupScanToComp'.
+
+Hint: In the original recording this function was called after 'GET /DevMgmt/DiscoveryTree.xml', but apparently it has to be the first request to choose which request needs to be used next.
+
+_Request_
+```http
+GET /WalkupScanToComp/WalkupScanToCompCaps HTTP/1.1
+HOST: 192.168.1.7:8080
+```
+_Response when only WalkupScan API is supported_
+```http
+HTTP/1.1 404 Not Found
+Server: HP HTTP Server; HP Officejet 6500 E710n-z - CN557A; Serial Number: CN19K340MP05JW; Chianti_pp_usr_hf Built:Mon May 16, 2016 12:22:43PM {CIP1FN1621AR, ASIC id 0x001c2105}
+Content-Length: 0
+Cache-Control: must-revalidate, max-age=0
+Pragma: no-cache
+```
+
+_Response when only WalkupScanToComp API is supported_
+```http
+HTTP/1.1 200 OK
+Server: HP HTTP Server; HP Deskjet 3520 series - CX052B; Serial Number: CN28F14C4105SY; Stuttgart_pp_usr_hf Built:Mon Dec 21, 2015 09:48:45AM {STP1FN1552AR, ASIC id 0x00340104}
+Content-Type: text/xml
+Cache-Control: must-revalidate, max-age=0
+Pragma: no-cache
+Content-Length: 676
+
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<wus:WalkupScanToCompCaps xsi:schemaLocation="http://www.hp.com/schemas/imaging/con/ledm/walkupscan/2010/09/28 WalkupScanToComp.xsd" xmlns:dd="http://www.hp.com/schemas/imaging/con/dictionaries/1.0/" xmlns:wus="http://www.hp.com/schemas/imaging/con/ledm/walkupscan/2010/09/28" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<wus:MaxNetworkDestinations>15</wus:MaxNetworkDestinations>
+	<wus:SupportsMultiItemScanFromPlaten>false</wus:SupportsMultiItemScanFromPlaten>
+	<wus:UserActionTimeout>
+		<dd:ValueFloat>60</dd:ValueFloat>
+		<dd:Unit>seconds</dd:Unit>
+	</wus:UserActionTimeout>
+</wus:WalkupScanToCompCaps>
+```
 ### `GET /WalkupScan/WalkupScanDestinations`
 
 Lookup if a destination is registered on the printer for: `LAPTOP-BSHRTBV8` (it doesn't)
@@ -76,6 +118,16 @@ Pragma: no-cache
 	</wus:WalkupScanDestination>
 </wus:WalkupScanDestinations>
 ```
+
+In case the scanner uses the newer WalkupScanToComp API, the GET request has to go to the URL /WalkupScanToComp/WalkupScanToCompDestinations and would return the following xml (in case there is no desination registered yet):
+_Response_
+```http
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<wus:WalkupScanToCompDestinations xsi:schemaLocation="http://www.hp.com/schemas/imaging/con/ledm/walkupscan/2010/09/28 WalkupScanToComp.xsd" xmlns:wus="http://www.hp.com/schemas/imaging/con/ledm/walkupscan/2010/09/28" xmlns:dd="http://www.hp.com/schemas/imaging/con/dictionaries/1.0/" xmlns:dd3="http://www.hp.com/schemas/imaging/con/dictionaries/2009/04/06" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+</wus:WalkupScanToCompDestinations>
+```
+
 ### `POST /WalkupScan/WalkupScanDestinations`
 
 Register a new `LAPTOP-BSHRTBV8` destination.
@@ -104,6 +156,16 @@ Location: http://192.168.1.7:8080/WalkupScan/WalkupScanDestinations/1cb3125d-7bd
 Cache-Control: must-revalidate, max-age=0
 Pragma: no-cache
 Content-Length: 0
+```
+
+In case the scanner uses the newer WalkupScanToComp API, the POST request has to go to the URL /WalkupScanToComp/WalkupScanToCompDestinations with the following xml content. Note that it seems to be relevant to use the newer namespaces/schema from 2010, otherwise you get a HTTP 400 error.
+```http
+<?xml version="1.0" encoding="UTF-8"?>
+<WalkupScanToCompDestination xmlns="http://www.hp.com/schemas/imaging/con/ledm/walkupscan/2010/09/28" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hp.com/schemas/imaging/con/ledm/walkupscan/2010/09/28 WalkupScanToComp.xsd">
+	<Hostname xmlns="http://www.hp.com/schemas/imaging/con/dictionaries/2009/04/06">LAPTOP-BSHRTBV8</Hostname>
+	<Name xmlns="http://www.hp.com/schemas/imaging/con/dictionaries/1.0/">LAPTOP-BSHRTBV8</Name>
+	<LinkType>Network</LinkType>
+</WalkupScanToCompDestination>
 ```
 ### `GET /EventMgmt/EventTable`
 
@@ -222,6 +284,25 @@ Pragma: no-cache
 		</wus:WalkupScanSettings>
 	</wus:WalkupScanDestination>
 </wus:WalkupScanDestinations>
+```
+
+In case the scanner uses the newer WalkupScanToComp API, the GET request has to go to the URL /WalkupScanToComp/WalkupScanToCompDestinations/1cb3125d-7bde-1f09-8da2-2c768ab21113 and would return the following xml:
+_Response_
+```http
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<wus:WalkupScanToCompDestination xsi:schemaLocation="http://www.hp.com/schemas/imaging/con/ledm/walkupscan/2010/09/28 WalkupScanToComp.xsd" xmlns:dd="http://www.hp.com/schemas/imaging/con/dictionaries/1.0/" xmlns:dd3="http://www.hp.com/schemas/imaging/con/dictionaries/2009/04/06" xmlns:scantype="http://www.hp.com/schemas/imaging/con/ledm/scantype/2008/03/17" xmlns:wus="http://www.hp.com/schemas/imaging/con/ledm/walkupscan/2010/09/28" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<dd:ResourceURI>/WalkupScanToComp/WalkupScanToCompDestinations/1cb3125d-7bde-1f09-8da2-2c768ab21113</dd:ResourceURI>
+	<dd:Name>LAPTOP-BSHRTBV8</dd:Name>
+	<dd3:Hostname>LAPTOP-BSHRTBV8</dd3:Hostname>
+	<wus:LinkType>Network</wus:LinkType>
+	<wus:WalkupScanToCompSettings>
+		<scantype:ScanSettings>
+			<dd:ScanPlexMode>Simplex</dd:ScanPlexMode>
+		</scantype:ScanSettings>
+		<wus:Shortcut>SaveDocument1</wus:Shortcut>
+	</wus:WalkupScanToCompSettings>
+</wus:WalkupScanToCompDestination>
 ```
 ### `GET /DevMgmt/DiscoveryTree.xml`
 
@@ -479,23 +560,6 @@ Pragma: no-cache
 	</ledm:SupportedIfc>
 </ledm:DiscoveryTree>
 ```
-### `GET /WalkupScanToComp/WalkupScanToCompCaps`
-
-It query this resource that is not found... (I do no know the reason why)
-
-_Request_
-```http
-GET /WalkupScanToComp/WalkupScanToCompCaps HTTP/1.1
-HOST: 192.168.1.7:8080
-```
-_Response_
-```http
-HTTP/1.1 404 Not Found
-Server: HP HTTP Server; HP Officejet 6500 E710n-z - CN557A; Serial Number: CN19K340MP05JW; Chianti_pp_usr_hf Built:Mon May 16, 2016 12:22:43PM {CIP1FN1621AR, ASIC id 0x001c2105}
-Content-Length: 0
-Cache-Control: must-revalidate, max-age=0
-Pragma: no-cache
-```
 ### `GET /Scan/ScanCaps.xml`
 
 Getting `ScanCaps.xml` (?Scanner capabilities?)
@@ -737,7 +801,8 @@ Content-Length: 6458
 ```
 ### `GET /Scan/Status`
 
-Getting the scanner status: `Idle` and Afd `Loaded` (It could be `Empty`)
+Getting the scanner status: `Idle` and Afd `Loaded` (It could be `Empty`).
+Note that the tag AdfState is missing when the scanner has no automatic document feeder.
 
 _Request_
 ```http
@@ -760,6 +825,7 @@ Content-Length: 283
 	<AdfState>Loaded</AdfState>
 </ScanStatus>
 ```
+
 ### `GET /WalkupScan/WalkupScanDestinations`
 
 Query one more time the `/WalkupScan/WalkupScanDestinations`. Why ?

--- a/src/Destination.ts
+++ b/src/Destination.ts
@@ -16,22 +16,29 @@ export default class Destination {
   private readonly name: string;
   private readonly hostname: string;
   private readonly linkType: string;
+  private readonly toComp: boolean;
 
-  constructor(name: string, hostname: string) {
+  constructor(name: string, hostname: string, toComp: boolean) {
     this.name = name;
     this.hostname = hostname;
     this.linkType = "Network";
+    this.toComp = toComp;
   }
 
   async toXML() {
-    let rawDestination =
-      '<?xml version="1.0" encoding="UTF-8"?>\n' +
-      '<WalkupScanDestination xmlns="http://www.hp.com/schemas/imaging/con/rest/walkupscan/2009/09/21" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" \n' +
-      'xsi:schemaLocation="http://www.hp.com/schemas/imaging/con/rest/walkupscan/2009/09/21 WalkupScanDestinations.xsd">\n' +
-      '<Hostname xmlns="http://www.hp.com/schemas/imaging/con/dictionaries/2009/04/06"></Hostname>\n' +
-      '<Name xmlns="http://www.hp.com/schemas/imaging/con/dictionaries/1.0/"></Name>\n' +
-      "<LinkType>Network</LinkType>\n" +
-      "</WalkupScanDestination>";
+    let rawDestination = '<?xml version="1.0" encoding="UTF-8"?>\n';
+    if (this.toComp) {
+      rawDestination += '<WalkupScanDestination xmlns="http://www.hp.com/schemas/imaging/con/ledm/walkupscan/2010/09/28" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+                        'xsi:schemaLocation="http://www.hp.com/schemas/imaging/con/ledm/walkupscan/2010/09/28 WalkupScan.xsd">\n'
+    } else {
+      rawDestination += '<WalkupScanDestination xmlns="http://www.hp.com/schemas/imaging/con/rest/walkupscan/2009/09/21" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" \n' +
+                        'xsi:schemaLocation="http://www.hp.com/schemas/imaging/con/rest/walkupscan/2009/09/21 WalkupScanDestinations.xsd">\n'
+    }
+      
+    rawDestination += '\t<Hostname xmlns="http://www.hp.com/schemas/imaging/con/dictionaries/2009/04/06"></Hostname>\n' +
+                      '\t<Name xmlns="http://www.hp.com/schemas/imaging/con/dictionaries/1.0/"></Name>\n' +
+                      '\t<LinkType>Network</LinkType>\n' +
+                      '</WalkupScanDestination>';
 
     const parsed = (await util.promisify(parser.parseString)(
       rawDestination
@@ -42,6 +49,11 @@ export default class Destination {
     parsed.WalkupScanDestination.LinkType[0] = this.linkType;
 
     let builder = new xml2js.Builder();
-    return builder.buildObject(parsed);
+    let xml = builder.buildObject(parsed);
+    if (this.toComp) {
+      return xml.replace(/WalkupScan/g, 'WalkupScanToComp');
+    } else {
+      return xml;
+    }
   }
 }

--- a/src/ScanStatus.ts
+++ b/src/ScanStatus.ts
@@ -18,7 +18,12 @@ export default class ScanStatus {
   }
 
   get adfState(): string {
-    return this.data["ScanStatus"].AdfState["0"];
+    if (this.data["ScanStatus"].hasOwnProperty("AdfState")) //not all printers have an automatic document feeder
+    {
+      return this.data["ScanStatus"].AdfState["0"];
+    } else {
+      return "";
+    }
   }
 
   isLoaded(): boolean {

--- a/src/WalkupScanToCompDestination.ts
+++ b/src/WalkupScanToCompDestination.ts
@@ -1,0 +1,53 @@
+"use strict";
+
+import WalkupScanDestination from "./WalkupScanDestination";
+
+export interface WalkupScanToCompDestinationData {
+  "dd:Name": string[];
+  "dd:ResourceURI": string[];
+  "dd3:Hostname": string[];
+  "wus:WalkupScanToCompDestination": {
+    "wus:WalkupScanToCompSettings": {
+      "0": {
+        "scantype:Scansettings": {
+          "0": {
+            "dd:ScanPlexMode": string[];
+          };
+        };
+        "wus:Shortcut": string[]; //can be 'SaveDocument1' or 'SavePhoto1'
+      };
+    };
+  };
+}
+
+export default class WalkupScanToCompDestination {
+  private readonly data: WalkupScanToCompDestinationData;
+  constructor(data: WalkupScanToCompDestinationData) {
+    this.data = data;
+  }
+
+  get name(): string {
+    return this.data["dd:Name"][0];
+  }
+
+  get hostname(): string {
+    return this.data["dd3:Hostname"][0];
+  }
+
+  get resourceURI(): string {
+    return this.data["dd:ResourceURI"][0];
+  }
+
+  get shortcut(): string {
+    if (this.data["wus:WalkupScanToCompDestination"].hasOwnProperty("wus:WalkupScanToCompSettings")) {
+      return this.data["wus:WalkupScanToCompDestination"]["wus:WalkupScanToCompSettings"][
+        "0"
+      ]["wus:Shortcut"][0];
+    }
+    return "";
+  }
+
+  getContentType(): string {
+    return this.shortcut === "SaveDocument1" ? "Document" : "Photo";
+  }
+}

--- a/src/WalkupScanToCompDestinations.ts
+++ b/src/WalkupScanToCompDestinations.ts
@@ -1,0 +1,29 @@
+"use strict";
+
+import WalkupScanToCompDestination, {
+  WalkupScanToCompDestinationData
+} from "./WalkupScanToCompDestination";
+
+export interface WalkupScanToCompDestinationsData {
+  "wus:WalkupScanToCompDestinations": {
+    "wus:WalkupScanToCompDestination": WalkupScanToCompDestinationData[];
+  };
+}
+
+export default class WalkupScanToCompDestinations {
+  private readonly data: WalkupScanToCompDestinationsData;
+  constructor(data: WalkupScanToCompDestinationsData) {
+    this.data = data;
+  }
+
+  get destinations(): WalkupScanToCompDestination[] {
+    let WalkupScanToCompDestinations = this.data["wus:WalkupScanToCompDestinations"];
+    if (WalkupScanToCompDestinations.hasOwnProperty("wus:WalkupScanToCompDestination")) {
+      return WalkupScanToCompDestinations["wus:WalkupScanToCompDestination"].map(
+        x => new WalkupScanToCompDestination(x)
+      );
+    } else {
+      return [];
+    }
+  }
+}


### PR DESCRIPTION
Hi, 
i added support for my All-in-One Printer HP Deskjet 3520.
Basically it uses the same API as yours except 'WalkupScan' is replaced with 'WalkupScanToComp' in all URLs and XML contents and i use the API call /WalkupScanToComp/WalkupScanToCompCaps to automatically distinguish if WalkupScan or WalkupScanToComp has to be used. 

I took care that it is still working with your HP Officejet Printer.