### PR TITLE
Command line arguments and docker support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,12 +8,14 @@
             "type": "node",
             "request": "launch",
             "name": "Launch Program",
-            "skipFiles": [
-                "<node_internals>/**"
-            ],
-            "cwd": "${workspaceRoot}",
-            "runtimeArgs": ["-r", "ts-node/register"],
-            "args": ["${workspaceRoot}/src/index.ts"]
-        }
+            "program": "${workspaceFolder}/src/index.ts",
+            "preLaunchTask": "tsc: build - tsconfig.json",
+            "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+            "args": [
+                //"-ip", "192.168.0.5"
+                "-p", "Deskjet 3520 series",
+                "-f", "'scan'_dd.mm.yyyy_hh:MM:ss"
+            ]
+        },
     ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:alpine as build
+WORKDIR /app
+
+ADD . .
+RUN yarn install -d \
+ && yarn build \
+ && rm dist/*.d.ts dist/*.js.map
+
+FROM node:alpine as app
+ENV NODE_ENV production
+ADD root/ /
+
+# add S6 Overlay, install shadow (for groupmod and usermod) and tzdata (for TZ env variable)
+ADD https://github.com/just-containers/s6-overlay/releases/latest/download/s6-overlay-amd64.tar.gz /tmp/
+RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C / \
+ && apk add --no-cache shadow tzdata
+
+# add builded app
+WORKDIR /app
+COPY --from=build /app/dist/ /app/package.json ./
+RUN yarn install -d \
+ && yarn cache clean --force
+
+VOLUME ["/scan"]
+ENTRYPOINT ["/init"]
+CMD ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -14,13 +14,63 @@ For this purpose, the original HP Windows application's interaction with the dev
 This project is not endorsed by nor affiliated with HP.
 
 ## Usage
-```
+```sh
 git clone ...
 cd node-hp-scan-to
 yarn install -d
-# now edit src/index.ts and set your printer in line "service.name.startsWith("Officejet 6500 E710n-z")"
-ts-node src/index.ts
+yarn build
+# now start the program with the ip or name of the desired printer
+node dist/index.js -ip 192.168.1.4 # or -n "Officejet 6500 E710n-z"
 ```
+
+### Command line options
+- `-ip` or `--address` followed by the ip address of the printer, i.e. `-ip 192.168.0.5`. This overrides `-p`.
+- `-n` or `--name` followed by the printer name, it probably contains spaces so it needs to be quoted, i.e. `-name "Officejet 6500 E710n-z"`
+- `-d` or `--directory` followed by the directory path where the scanned documents should be saved, i.e. `-d ~/Documents/Scans`. Defaults to `/tmp/scan-to-pc<random value>` when not set.
+- `-p` or `--pattern` followed by the pattern for the filename without file extension, i.e. `"scan"_dd.mm.yyyy_hh:MM:ss` to name the scanned file `scan_19.04.2021_17:26:47`. Date and time patterns are replaced by the current date and time, text that should not be replaced need to be inside quotes. Documentation for the pattern can be found [here](https://www.npmjs.com/package/dateformat) in the section `Mask options`. Defaults to `scanPage<increasing number>` when not set.
+
+### Run with docker
+Be aware that with docker you have to specify the ip address of the printer via the `IP` environment variable, because 
+bonjour service discovery uses multicast network traffic which by default doesn't work in docker.
+You could however use docker's macvlan networking, this way you can use service discovery and the `NAME` environment variable.
+
+All scanned files are written to the volume `/scan`, the filename can be changed with the `PATTERN` environment variable.
+For the correct permissions to the volume set the environment variables `PUID` and `PGID`.
+
+The name shown on the printer's display is the hostname of the docker container, which defaults to a random value so you may want to specify it via the `-hostname` argument.
+
+Example for docker:
+```sh
+git clone ...
+cd node-hp-scan-to
+docker build . -t node-hp-scan-to
+docker run -e IP=192.168.0.5 -e PGID=1000 -e PUID=1000 --hostname scan node-hp-scan-to
+```
+
+Example for docker-compose:
+Write the following `docker-compose.yml` file into this directory:
+```yml
+version: "3"
+
+services:
+  node-hp-scan-to:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: node-hp-scan-to
+    hostname: scan
+    environment:
+      - IP=192.168.0.5
+      - PATTERN="scan"_dd.mm.yyyy_hh:MM:ss
+      - PGID=1000
+      - PUID=1000
+      - TZ=Europe/London
+    volumes:
+      - /some/host/directory/or/volume:/scan
+    restart: always
+```
+Then run `docker-compose up -d --build`.
 
 ## Debugging
 I'm using Visual Studio Code to debug this application, so instead of running ts-node just enter `code .` and press F5 to start debugging.
+You may want to set your printers ip or name in `.vscode/launch.json`.

--- a/package.json
+++ b/package.json
@@ -52,8 +52,11 @@
     "typescript": "^4.0.2"
   },
   "dependencies": {
+    "@types/dateformat": "^3.0.1",
     "axios": "^0.21.0",
     "bonjour": "^3.5.0",
+    "commander": "^7.2.0",
+    "dateformat": "^4.5.1",
     "xml2js": "^0.4.19"
   }
 }

--- a/root/entrypoint.sh
+++ b/root/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/with-contenv sh
+
+ARGS="-d /scan "
+
+if [ ! -z "$IP" ]; then
+    ARGS="${ARGS} -ip ${IP}"
+fi
+
+if [ ! -z "$NAME" ]; then
+    ARGS="${ARGS} -n ${NAME}"
+fi
+
+if [ ! -z "$PATTERN" ]; then
+    ARGS="${ARGS} -p ${PATTERN}"
+fi
+
+cd /app
+
+s6-setuidgid node \
+    node index.js $ARGS

--- a/root/etc/cont-init.d/10-adduser
+++ b/root/etc/cont-init.d/10-adduser
@@ -1,0 +1,16 @@
+#!/usr/bin/with-contenv sh
+
+PUID=${PUID:-911}
+PGID=${PGID:-911}
+
+groupmod -o -g "$PGID" node
+usermod -o -u "$PUID" node
+
+echo "
+User uid:    $(id -u node)
+User gid:    $(id -g node)
+-------------------------------------
+"
+
+chown -R node:node /app
+chown node:node /scan

--- a/src/HPApi.ts
+++ b/src/HPApi.ts
@@ -119,7 +119,7 @@ export default class HPApi {
     });
 
     if (response.status === 201) {
-      return response.headers.location;
+      return new URL(response.headers.location).pathname;
     } else {
       throw response;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,6 +26,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/dateformat@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/dateformat/-/dateformat-3.0.1.tgz#98d747a2e5e9a56070c6bf14e27bff56204e34cc"
+  integrity sha512-KlPPdikagvL6ELjWsljbyDIPzNCeliYkqRpI+zea99vBBbCIA5JNshZAwQKTON139c87y9qvTFVgkFd14rtS4g==
+
 "@types/node@*", "@types/node@^14.0.5":
   version "14.14.37"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.37.tgz#a3dd8da4eb84a996c36e331df98d82abd76b516e"
@@ -224,6 +229,11 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+commander@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -250,6 +260,11 @@ crypto-random-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
+
+dateformat@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.5.1.tgz#c20e7a9ca77d147906b6dc2261a8be0a5bd2173c"
+  integrity sha512-OD0TZ+B7yP7ZgpJf5K2DIbj3FZvFvxgFUuaqA/V5zTjAtAAXZ1E8bktHxmAGs4x5b7PflqA9LeQ84Og7wYtF7Q==
 
 debug@^2.2.0:
   version "2.6.9"


### PR DESCRIPTION
Hi,

This pull request adds command line arguments for the ip and name of the printer, the output directory and the filename.
So no one needs to manually change the printer name inside the source code. All the arguments are documented in the README.

And i added all the files needed to run it inside a docker container. Examples for how to build and run it via docker are in the README.
The docker container is built in a way all the popular images from https://www.linuxserver.io are built. It uses the `node:alpine` image, which is the smallest image available to run node.js, and i built the `Dockerfile` in a way that this software and all dependencies add only ~12MB to it. The application runs as user `node`. When the docker container is started, it runs the script `root/etc/cont-init.d/10-adduser` to set the correct permissions and then starts the application via `root/entrypoint.sh`.
This way i now run this software inside docker on my server and have all the scanned documents appear on a network share.

The second commit fixes a small bug where after registering a new scan session the full url was returned instead of only the basepath of the url (everything after the hostname). This leaded to the problem that no scan events were captured unless the software was started again where it reused the session from before and the code correctly returned only the basepath of the url.