### PR TITLE
add support for commandline parameters in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ RUN yarn install -d \
 
 VOLUME ["/scan"]
 ENTRYPOINT ["/init"]
-CMD ["/entrypoint.sh"]
+CMD ["/app.sh"]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ node dist/index.js -ip 192.168.1.4 # or -n "Officejet 6500 E710n-z"
 - `-n` or `--name` followed by the printer name, it probably contains spaces, so it needs to be quoted, i.e. `-name "Officejet 6500 E710n-z"`
 - `-d` or `--directory` followed by the directory path where the scanned documents should be saved, i.e. `-d ~/Documents/Scans`. Defaults to `/tmp/scan-to-pc<random value>` when not set.
 - `-p` or `--pattern` followed by the pattern for the filename without file extension, i.e. `"scan"_dd.mm.yyyy_hh:MM:ss` to name the scanned file `scan_19.04.2021_17:26:47`. Date and time patterns are replaced by the current date and time, text that should not be replaced need to be inside quotes. Documentation for the pattern can be found [here](https://www.npmjs.com/package/dateformat) in the section `Mask options`. Defaults to `scanPage<increasing number>` when not set.
+- `-D, --debug"` enables debug logs.
 
 ### Run with docker
 Be aware that with docker you have to specify the ip address of the printer via the `IP` environment variable, because 
@@ -39,6 +40,8 @@ You could however use docker's macvlan networking, this way you can use service 
 
 All scanned files are written to the volume `/scan`, the filename can be changed with the `PATTERN` environment variable.
 For the correct permissions to the volume set the environment variables `PUID` and `PGID`.
+
+To enable debug logs set the environment variable `CMDLINE` to `-D`. Can also be used for any other command line parameters.
 
 The name shown on the printer's display is the hostname of the docker container, which defaults to a random value, so you may want to specify it via the `-hostname` argument.
 
@@ -72,8 +75,8 @@ services:
       - /some/host/directory/or/volume:/scan
     restart: always
 ```
-
 Then run `docker-compose up -d --build`.
+To 
 
 Public Pre-built Docker image:
 - https://hub.docker.com/repository/docker/manuc66/node-hp-scan-to

--- a/root/app.sh
+++ b/root/app.sh
@@ -14,7 +14,11 @@ if [ ! -z "$PATTERN" ]; then
     ARGS="${ARGS} -p ${PATTERN}"
 fi
 
+if [ ! -z "$CMDLINE" ]; then
+    ARGS="${ARGS} ${CMDLINE}"
+fi
+
 cd /app
 
 s6-setuidgid node \
-    node index.js $ARGS
+    node index.js $ARGS "$@"


### PR DESCRIPTION
Hi, 
i just saw you added command line parameter `-D` for debug logs and in #325 this command line parameter is needed for the docker container and there's no response since 8 days, so i thought you might need some help :smirk:

So this adds the ability to add any command line parameters via docker by using the new environment variable `CMDLINE`.

To enable debug logs use `docker run -e IP=192.168.0.1 -e CMDLINE=-D manuc66/node-hp-scan-to` or add `- CMDLINE=-D` it to the environment block when using docker-compose.
It's possible to use multiple command line parameters, just quote the parameters, i.e. `CMDLINE="-ip 192.168.0.1 -D"` would also work (or any new environment variable).

I renamed the script entrypoint.sh to app.sh, because it's not called via docker's ENTRYPOINT command.
The `"$@"` at the end of app.sh is there to allow command line parameters on the script app.sh itself, so someone could start a shell inside the container (via `docker run -it manuc66/node-hp-scan-to /bin/sh`) and then run `/app.sh -ip 192.168.0.1 -D` inside.
Or just directly call the script via `docker run -it manuc66/node-hp-scan-to /app.sh -ip 192.168.0.1 -D`.