### PR TITLE
update s6-overlay to version 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,14 @@ FROM node:alpine as app
 ENV NODE_ENV production
 ADD root/ /
 
-# add S6 Overlay, install shadow (for groupmod and usermod) and tzdata (for TZ env variable)
-ADD https://github.com/just-containers/s6-overlay/releases/download/v2.2.0.3/s6-overlay-amd64.tar.gz /tmp/
-RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C / \
- && apk add --no-cache shadow tzdata
+# add S6 Overlay
+ADD https://github.com/just-containers/s6-overlay/releases/latest/download/s6-overlay-noarch.tar.xz /tmp
+RUN tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz
+ADD https://github.com/just-containers/s6-overlay/releases/latest/download/s6-overlay-x86_64.tar.xz /tmp
+RUN tar -C / -Jxpf /tmp/s6-overlay-x86_64.tar.xz
+
+# install shadow (for groupmod and usermod) and tzdata (for TZ env variable)
+RUN apk add --no-cache shadow tzdata
 
 # add builded app
 WORKDIR /app

--- a/root/app.sh
+++ b/root/app.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/with-contenv sh
+#!/command/with-contenv sh
 
 ARGS="-d /scan "
 

--- a/root/etc/cont-init.d/10-adduser
+++ b/root/etc/cont-init.d/10-adduser
@@ -1,4 +1,4 @@
-#!/usr/bin/with-contenv sh
+#!/command/with-contenv sh
 
 PUID=${PUID:-911}
 PGID=${PGID:-911}


### PR DESCRIPTION
Now that version 3 of s6-overlay finally uses files without a version number, it's now as easy as in version 2 to automatically use the latest version. So this pull request includes all changes to switch to the latest version of s6-overlay.

