### PR TITLE
Support the full scanner image size

### DIFF
--- a/src/DeviceCapabilities.ts
+++ b/src/DeviceCapabilities.ts
@@ -1,4 +1,9 @@
 export interface DeviceCapabilities {
   supportsMultiItemScanFromPlaten: boolean;
   useWalkupScanToComp: boolean;
+
+  platenMaxWidth: number | null;
+  platenMaxHeight: number | null;
+  adfMaxWidth: number | null;
+  adfMaxHeight: number | null;
 }

--- a/src/ScanCaps.ts
+++ b/src/ScanCaps.ts
@@ -3,7 +3,23 @@ import { Parser } from "xml2js";
 const parser = new Parser();
 import { promisify } from "util";
 const parseString = promisify<string, ScanCapsData>(parser.parseString);
-export interface ScanCapsData {}
+
+export interface ScanCapsData {
+  "ScanCaps": {
+    "Platen": {
+      "InputSourceCaps": {
+        "MaxWidth": number,
+        "MaxHeight": number
+      }[]
+    }[],
+    "Adf": {
+      "InputSourceCaps": {
+        "MaxWidth": number,
+        "MaxHeight": number
+      }[]
+    }[]
+  }
+}
 
 export default class ScanCaps {
   private readonly data: ScanCapsData;
@@ -15,5 +31,21 @@ export default class ScanCaps {
   static async createScanCaps(content: string): Promise<ScanCaps> {
     const parsed = await parseString(content);
     return new ScanCaps(parsed);
+  }
+
+  get PlatenMaxWidth(): number | null {
+    return this.data["ScanCaps"]["Platen"][0]["InputSourceCaps"][0]["MaxWidth"] || null
+  }
+
+  get PlatenMaxHeight(): number | null {
+    return this.data["ScanCaps"]["Platen"][0]["InputSourceCaps"][0]["MaxHeight"] || null
+  }
+
+  get AdfMaxWidth(): number | null {
+    return this.data["ScanCaps"]["Adf"][0]["InputSourceCaps"][0]["MaxWidth"] || null
+  }
+
+  get AdfMaxHeight(): number | null {
+    return this.data["ScanCaps"]["Adf"][0]["InputSourceCaps"][0]["MaxHeight"] || null
   }
 }

--- a/src/ScanJobSettings.ts
+++ b/src/ScanJobSettings.ts
@@ -6,17 +6,23 @@ export default class ScanJobSettings {
   private readonly inputSource: "Adf" | "Platen";
   private readonly contentType: "Document" | "Photo";
   private readonly resolution: number;
+  private readonly width: number | null;
+  private readonly height: number | null;
   private readonly isDuplex: boolean;
 
   constructor(
     inputSource: "Adf" | "Platen",
     contentType: "Document" | "Photo",
     resolution: number,
+    width: number | null,
+    height: number | null,
     isDuplex: boolean
   ) {
     this.inputSource = inputSource;
     this.contentType = contentType;
     this.resolution = resolution;
+    this.width = width;
+    this.height = height;
     this.isDuplex = isDuplex;
   }
 
@@ -26,7 +32,7 @@ export default class ScanJobSettings {
       '<ScanSettings xmlns="http://www.hp.com/schemas/imaging/con/cnx/scan/2008/08/19" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hp.com/schemas/imaging/con/cnx/scan/2008/08/19 Scan Schema - 0.26.xsd">\n' +
       "\t<XResolution>200</XResolution>\n" +
       "\t<YResolution>200</YResolution>\n" +
-      "\t<XStart>33</XStart>\n" +
+      "\t<XStart>0</XStart>\n" +
       "\t<YStart>0</YStart>\n" +
       "\t<Width>2481</Width>\n" +
       "\t<Height>3507</Height>\n" +
@@ -53,6 +59,14 @@ export default class ScanJobSettings {
 
     parsed.ScanSettings.XResolution[0] = this.resolution;
     parsed.ScanSettings.YResolution[0] = this.resolution;
+
+    if (this.width !== null) {
+      parsed.ScanSettings.Width = this.width;
+    }
+
+    if (this.height !== null) {
+      parsed.ScanSettings.Height = this.height;
+    }
 
     parsed.ScanSettings.InputSource[0] = this.inputSource;
     if (this.inputSource === "Adf" && this.isDuplex) {

--- a/src/readDeviceCapabilities.ts
+++ b/src/readDeviceCapabilities.ts
@@ -1,6 +1,7 @@
 import { DeviceCapabilities } from "./DeviceCapabilities";
 import HPApi from "./HPApi";
 import WalkupScanToCompCaps from "./WalkupScanToCompCaps";
+import ScanCaps from "./ScanCaps"
 
 export async function readDeviceCapabilities(): Promise<DeviceCapabilities> {
   let supportsMultiItemScanFromPlaten = true;
@@ -30,17 +31,22 @@ export async function readDeviceCapabilities(): Promise<DeviceCapabilities> {
     console.log("Unknown device!");
   }
 
+  let scanCaps: ScanCaps | null = null;
   if (discoveryTree.ScanJobManifestURI != null) {
     const scanJobManifest = await HPApi.getScanJobManifest(
       discoveryTree.ScanJobManifestURI
     );
     if (scanJobManifest.ScanCapsURI != null) {
-      await HPApi.getScanCaps(scanJobManifest.ScanCapsURI);
+      scanCaps = await HPApi.getScanCaps(scanJobManifest.ScanCapsURI);
     }
   }
 
   return {
     supportsMultiItemScanFromPlaten,
     useWalkupScanToComp: walkupScanToCompCaps != null,
+    platenMaxWidth: scanCaps?.PlatenMaxWidth || null,
+    platenMaxHeight: scanCaps?.PlatenMaxHeight || null,
+    adfMaxWidth: scanCaps?.AdfMaxWidth || null,
+    adfMaxHeight: scanCaps?.AdfMaxHeight || null,
   };
 }

--- a/src/scanProcessing.ts
+++ b/src/scanProcessing.ts
@@ -402,6 +402,8 @@ export async function saveScan(
     inputSource,
     contentType,
     scanConfig.resolution,
+    inputSource === "Adf" ? deviceCapabilities.adfMaxWidth : deviceCapabilities.platenMaxWidth,
+    inputSource === "Adf" ? deviceCapabilities.adfMaxHeight : deviceCapabilities.platenMaxHeight,
     isDuplex
   );
 
@@ -474,6 +476,8 @@ export async function scanFromAdf(
     "Adf",
     contentType,
     adfAutoScanConfig.resolution,
+    null,
+    null,
     adfAutoScanConfig.isDuplex
   );
 

--- a/test/ScanJobSettings.test.ts
+++ b/test/ScanJobSettings.test.ts
@@ -7,7 +7,7 @@ import * as fs from "fs/promises";
 describe("ScanJobSettings", () => {
   describe("toXML",  () => {
     it("Allows to describe an ADF two side", async () => {
-      const scanJobSettings = new ScanJobSettings("Adf", "Document", 200, true);
+      const scanJobSettings = new ScanJobSettings("Adf", "Document", 200, null, null, true);
 
       const content: string = await fs.readFile(
         path.resolve(__dirname, "./asset/adf_duplex_job.xml"), {encoding:'utf8' }
@@ -16,7 +16,7 @@ describe("ScanJobSettings", () => {
     });
 
     it("Allows to describe an ADF single side", async () => {
-      const scanJobSettings = new ScanJobSettings("Adf", "Document", 200, false);
+      const scanJobSettings = new ScanJobSettings("Adf", "Document", 200, null, null, false);
 
       const content: string = await fs.readFile(
         path.resolve(__dirname, "./asset/adf_simplex_job.xml"), {encoding:'utf8' }
@@ -25,12 +25,21 @@ describe("ScanJobSettings", () => {
     });
 
     it("Allows to describe dpi of 300", async () => {
-      const scanJobSettings = new ScanJobSettings("Adf", "Document", 300, false);
+      const scanJobSettings = new ScanJobSettings("Adf", "Document", 300, null, null, false);
 
       const content: string = await fs.readFile(
         path.resolve(__dirname, "./asset/300_dpi_job.xml"), {encoding:'utf8' }
       );
       expect((await scanJobSettings.toXML()).trimEnd()).to.be.eq(content.trimEnd().replace(/\r\n/g, "\n"));
     });
+
+    it ("Allows to describe a custom width and height", async () => {
+      const scanJobSettings = new ScanJobSettings("Adf", "Document", 200, 1000, 4000, false);
+
+      const content: string = await fs.readFile(
+        path.resolve(__dirname, "./asset/adf_simplex_custom_job.xml"), {encoding:'utf8' }
+      );
+      expect((await scanJobSettings.toXML()).trimEnd()).to.be.eq(content.trimEnd().replace(/\r\n/g, "\n"));
+    })
   });
 });

--- a/test/asset/adf_duplex_job.xml
+++ b/test/asset/adf_duplex_job.xml
@@ -2,7 +2,7 @@
 <ScanSettings xmlns="http://www.hp.com/schemas/imaging/con/cnx/scan/2008/08/19" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hp.com/schemas/imaging/con/cnx/scan/2008/08/19 Scan Schema - 0.26.xsd">
 	<XResolution>200</XResolution>
 	<YResolution>200</YResolution>
-	<XStart>33</XStart>
+	<XStart>0</XStart>
 	<YStart>0</YStart>
 	<Width>2481</Width>
 	<Height>3507</Height>

--- a/test/asset/adf_simplex_custom_job.xml
+++ b/test/asset/adf_simplex_custom_job.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <ScanSettings xmlns="http://www.hp.com/schemas/imaging/con/cnx/scan/2008/08/19" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hp.com/schemas/imaging/con/cnx/scan/2008/08/19 Scan Schema - 0.26.xsd">
-	<XResolution>300</XResolution>
-	<YResolution>300</YResolution>
+	<XResolution>200</XResolution>
+	<YResolution>200</YResolution>
 	<XStart>0</XStart>
 	<YStart>0</YStart>
-	<Width>2481</Width>
-	<Height>3507</Height>
+	<Width>1000</Width>
+	<Height>4000</Height>
 	<Format>Jpeg</Format>
 	<CompressionQFactor>0</CompressionQFactor>
 	<ColorSpace>Color</ColorSpace>

--- a/test/asset/adf_simplex_job.xml
+++ b/test/asset/adf_simplex_job.xml
@@ -2,7 +2,7 @@
 <ScanSettings xmlns="http://www.hp.com/schemas/imaging/con/cnx/scan/2008/08/19" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hp.com/schemas/imaging/con/cnx/scan/2008/08/19 Scan Schema - 0.26.xsd">
 	<XResolution>200</XResolution>
 	<YResolution>200</YResolution>
-	<XStart>33</XStart>
+	<XStart>0</XStart>
 	<YStart>0</YStart>
 	<Width>2481</Width>
 	<Height>3507</Height>


### PR DESCRIPTION
When querying for the scanner capabilities capture the full height and width for both the platen and ADF. Then pass these as the height and width for the job settings and update the job XML.

This allows for scans to scan up to the full size available for the input source rather than the hard-coded size that was previously used. This PR also removes the 33 pixel cutoff from the X axis.

I haven't really used Typescript before, so don't hesitate to point out better approaches if something isn't idiomatic.