### PR TITLE
Clean up Dockerfile Lint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN yarn install -d \
  && rm dist/*.d.ts dist/*.js.map
 
 FROM node:18-alpine AS app
-ENV NODE_ENV production
+ENV NODE_ENV=production
 ADD root/ /
 
 # sets version for s6 overlay

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine  as build
+FROM node:18-alpine AS build
 WORKDIR /app
 
 ADD . .
@@ -6,7 +6,7 @@ RUN yarn install -d \
  && yarn build \
  && rm dist/*.d.ts dist/*.js.map
 
-FROM node:18-alpine as app
+FROM node:18-alpine AS app
 ENV NODE_ENV production
 ADD root/ /
 


### PR DESCRIPTION
Fixes lint present in the Dockerfile.

Existing lint can be seen by running

```
docker build -t node-hp-scan-to:latest .
```

```
3 warnings found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 9)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 10)
```
