### PR TITLE
ADD HP PageWide 377dw MFP to reported to work on list

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Additionally, it has been reported to work on several other HP printer models.
 - HP Deskjet 5525
 - HP OfficeJet 8012
 - HP OfficeJet Pro 9012e
+- HP PageWide 377dw MFP
 
 There are good chances it also works on your HP All-in-One Printer.
 

--- a/README.md
+++ b/README.md
@@ -17,22 +17,22 @@ Its primary purpose is to enable users to scan documents directly from an HP dev
 
 ## Supported devices
 It has been developed and tested with the following HP All-in-One Printers:
-- HP Officejet 6500A Plus
 - HP Deskjet 3520
+- HP Officejet 6500A Plus
 - HP Smart Tank Plus 570 series
 
 Additionally, it has been reported to work on several other HP printer models.
 - HP Deskjet 3050 All-in-One Printer - J610a
+- HP Deskjet 5525
 - HP Officejet 3830
 - HP Officejet 5230
-- HP Officejet 6700 premium
 - HP Officejet 5740
+- HP Officejet 6700 premium
 - HP Officejet 6950
-- HP OfficeJet Pro 8025e
-- HP OfficeJet Pro 7720 Wide Format All-in-One
 - HP Officejet 8010 series
-- HP Deskjet 5525
 - HP OfficeJet 8012
+- HP OfficeJet Pro 7720 Wide Format All-in-One
+- HP OfficeJet Pro 8025e
 - HP OfficeJet Pro 9012e
 - HP PageWide 377dw MFP
 


### PR DESCRIPTION
Thank you for creating node-hp-scan-to.
so far (a couple hours) it works fine with my HP PageWide 377dw MFP

- this trivial PR adds that model to the _reported to work_ list
- this PR also sorts both lists alphabetically, fee free to drop 937b45b7540bdbb96d979bd12ad0a26aeb045111 from this PR and/or ask to have that alphabetical sort in a separate PR.

FWIW: for now I am using it, in a docker-compose file to simply drop files into a Paperless-ngx `consume/` folder.

```yaml
---
version: '3.6'

networks:
  paperless_net:
    external: false

services:
[…]
  webserver:
    container_name: paperless
    image: ghcr.io/paperless-ngx/paperless-ngx:latest
    networks:
      - paperless_net
    restart: unless-stopped
    depends_on:
      - postgres
      - broker
      - gotenberg
      - tika
    […]
    volumes:
      […]
      - /share/ZFS[…]_DATA/Paperless-ngx-shared/paperless-ngx/consume:/usr/src/paperless/consume
    environment:
      […]
      USERMAP_UID: 1000
      USERMAP_GID: 1000
  […]
  node-hp-scan-to:
    container_name: node-hp-scan-to
    image: manuc66/node-hp-scan-to:master
    restart: unless-stopped
    volumes:
      - /share/ZFS[…]_DATA/Paperless-ngx-shared/paperless-ngx/consume:/scan
    environment:
      PUID: 1000
      PGID: 1000
      IP: 192.168.[…]
      PATTERN: '"scan"-yyyy-mm-dd_hh:MM:ss'
      LABEL: Paperless-ngx
      RESOLUTION: 300
      TZ: Europe/Berlin
```

I might switch from filesystem to submission API later. Also not yet sure if I'll add to `depends_on:`

EDIT: signed both commits, force pushed and updated the hash of the _sort alphabetically_ commit at start of this text.