### PR TITLE
Fix duplex option reference for adf-autoscan option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -557,7 +557,7 @@ async function main() {
 
       const adfScanConfig: AdfAutoScanConfig = {
         ...scanConfig,
-        isDuplex: options.isDuplex || getConfig("autoscan_duplex") || false,
+        isDuplex: options.duplex || getConfig("autoscan_duplex") || false,
         generatePdf: options.pdf || getConfig("autoscan_pdf") || false,
         pollingInterval:
           options.pollingInterval ||


### PR DESCRIPTION
Great project!
I found with my printer that the `adf-autoscan --duplex` option was only resulting in one side being scanned.
It seems this is because the option should be referenced by `options.duplex` instead of `options.isDuplex`
Making this change gave me automatic duplex scanning as intended.