### PR TITLE
handle JobState "Blocked", appearing very often on OfficeJet 5230

### DIFF
--- a/src/hpModels/Job.ts
+++ b/src/hpModels/Job.ts
@@ -33,6 +33,7 @@ export enum JobState {
   Completed = "Completed",
   Processing = "Processing",
   Canceled = "Canceled",
+  Blocked = "Blocked",
 }
 
 export enum PageState {

--- a/src/scanJobHandlers.ts
+++ b/src/scanJobHandlers.ts
@@ -169,6 +169,9 @@ async function hpScanJobHandling(
       if (page !== null && job.jobState !== JobState.Canceled) {
         scanJobContent.elements.push(page);
       }
+    } else if (job.jobState === JobState.Blocked) {
+      console.log("Job blocked, waiting for printer to complete");
+      continue;
     } else {
       console.log("Job cancelled by device");
       break;


### PR DESCRIPTION
My HP OfficeJet 5230 quite often reports JobState "Blocked"  (happening in ~75% of all scans) which without my change is not handled in the code. Without my change it was almost impossible to scan multi-page documents.

See the following error reported by the current upstrem code, which is fixed (at least in my setup) with my changes:

> Waiting for scan event from: Paperless NGX (94107c99-8cf2-431d-83fb-088b23a4f3bc)
> Waiting for user input (attempt 1 of 50)
> Waiting for user input (attempt 2 of 50)
> Selected shortcut: SavePDF
> Scan mode: Simplex
> Scan event captured, saving scan #2
> Converting scan to PDF…
> ADF status: Empty
> Creating job with settings: {"inputSource":"Platen","contentType":"Document","resolution":300,"mode":"Color","width":2550,"height":3508,"isDuplex":false}
> New job created: http://192.168.2.149:8080/Jobs/JobList/6
> Error: "Blocked" is not a known JobState value, you would be kind as a reader of this message to fill an issue to help at better state handling.
>     at EnumUtils.getState (file:///app/hpModels/EnumUtils.js:4:19)
>     at get jobState (file:///app/hpModels/Job.js:41:26)
>     at hpScanJobHandling (file:///app/scanJobHandlers.js:83:16)
>     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
>     at async executeScanJob (file:///app/scanJobHandlers.js:192:20)
>     at async executeScanJobs (file:///app/scanJobHandlers.js:222:20)
>     at async saveScanFromEvent (file:///app/scanProcessing.js:108:5)
>     at async processScanWithDestination (file:///app/commands/listenCmd.js:86:28)
>     at async listenCmd (file:///app/commands/listenCmd.js:44:23)
>     at async Command.<anonymous> (file:///app/program.js:243:9)
> Iteration 17 (Errors so far: 15)
> Discovered available host destinations: Paperless NGX
> Waiting for scan event from: Paperless NGX (94107c99-8cf2-431d-83fb-088b23a4f3bc)