### PR TITLE
Document supported printer report process

### DIFF
--- a/.github/ISSUE_TEMPLATE/device_support_report.md
+++ b/.github/ISSUE_TEMPLATE/device_support_report.md
@@ -1,0 +1,23 @@
+---
+name: Device support report
+about: Report a printer or scanner that works with node-hp-scan-to
+title: "Device report: HP "
+labels: documentation
+assignees: ''
+
+---
+
+**Printer model**
+Exact model name shown by the printer UI or HP software.
+
+**How node-hp-scan-to was run**
+Command line, Docker, Docker Compose, or another setup. Include `--address`, `--name`, or the relevant environment variables if possible.
+
+**Mode tested**
+For example: `listen`, `single-scan`, or `adf-autoscan`.
+
+**Output tested**
+For example: JPG, PDF, ADF, duplex, Paperless-ngx, or Nextcloud.
+
+**Result**
+What worked, and anything that only works partially.

--- a/README.md
+++ b/README.md
@@ -58,12 +58,9 @@ This app has been developed and tested with the following HP All-in-One Printers
 - HP Smart Tank Plus 570 series
 - HP OfficeJet Pro 9019e
 
-Users have reported it also working on:
-
-- HP DeskJet 3050 (J610a),3522, 3775, 4670, 5525
-- HP Envy 4504, 4520, 5530, 7640
-- HP OfficeJet 250 Mobile, 3830, 5230, 5740, 6700 Premium, 6950, Pro 7730, 8010 series, 8025e, 9012e
-- HP PageWide 377dw MFP
+Users have reported it also working on additional devices. See
+[SUPPORTED_DEVICES.md](SUPPORTED_DEVICES.md) for the full community-reported list
+and the process for adding a new printer report.
 
 There is a good chance it also works on other unlisted HP All-in-One Printer.
 

--- a/SUPPORTED_DEVICES.md
+++ b/SUPPORTED_DEVICES.md
@@ -1,0 +1,56 @@
+# Supported Devices
+
+This page tracks HP printers and scanners that are known to work with
+`node-hp-scan-to`.
+
+## Tested During Development
+
+These devices were used while developing or testing the project:
+
+- HP DeskJet 3520
+- HP OfficeJet 6500A Plus
+- HP Smart Tank Plus 570 series
+- HP OfficeJet Pro 9019e
+
+## Community Reports
+
+Users have reported successful scans with these devices:
+
+- HP DeskJet 3050 (J610a)
+- HP DeskJet 3522
+- HP DeskJet 3775
+- HP DeskJet 4670
+- HP DeskJet 5525
+- HP Envy 4504
+- HP Envy 4520
+- HP Envy 5530
+- HP Envy 5532
+- HP Envy 7640
+- HP OfficeJet 250 Mobile
+- HP OfficeJet 3830
+- HP OfficeJet 5230
+- HP OfficeJet 5740
+- HP OfficeJet 6700 Premium
+- HP OfficeJet 6950
+- HP OfficeJet 8010 series
+- HP OfficeJet 8012
+- HP OfficeJet Pro 7720 Wide Format All-in-One
+- HP OfficeJet Pro 7730
+- HP OfficeJet Pro 8025e
+- HP OfficeJet Pro 9012e
+- HP PageWide 377dw MFP
+
+## Add A Printer Report
+
+If your printer works and is not listed yet, open a pull request that updates
+the list above. Include the following details in the pull request body:
+
+- Exact printer model shown by the printer UI or HP software
+- Connection type used by `node-hp-scan-to` (`--address`, `--name`, Docker, or
+  another setup)
+- Command or mode tested, such as `listen`, `single-scan`, or `adf-autoscan`
+- Output format tested, such as JPG or PDF
+- Anything that did not work, if the support is partial
+
+If you are not comfortable opening a pull request, open an issue with the same
+details and mention that it is a device support report.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "SUPPORTED_DEVICES.md"
   ],
   "engines": {
     "node": ">=20.11.0"


### PR DESCRIPTION
## Summary
- move the community-reported working printer list into `SUPPORTED_DEVICES.md`
- add the new HP Envy 5532 report from #830
- document what details to include when reporting another working printer
- add a dedicated device support report issue template for users who cannot open a PR
- include `SUPPORTED_DEVICES.md` in the npm package files so the README link works from npm too

Closes #830

## Validation
- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json ok')"`

Note: I did not run the full test suite because this only changes documentation/package metadata, not runtime code.
