### PR TITLE
ci: keep the docker 'latest' tag up to date

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
       - 'feature/**'
+    tags:
+      - 'v*'
   pull_request:
     branches: [ "master" ]
 
@@ -67,7 +69,7 @@ jobs:
             type=semver,pattern={{major}}
             type=ref,event=branch
           flavor: |
-            latest=false
+            latest=auto
 
       - name: Install pnpm
         uses: pnpm/action-setup@v3


### PR DESCRIPTION
## Summary

The Docker CI workflow stopped maintaining the `latest` tag (and the semver tags) since commit `1ba95d8f` (23 Mar 2026) removed the `v*` tag trigger and set `flavor.latest=false`. As a result the `latest` tag on Docker Hub stayed frozen on an image from April 2025, which silently broke users pulling `latest` (no emulated duplex support, see #1663).

## Changes

- Restore the `tags: ['v*']` push trigger so releases regenerate the semver tags (`x.y.z`, `x.y`, `x`)
- Switch `flavor.latest` from `false` to `auto` so the latest stable release is also tagged `latest`

This restores the tag semantics documented in the README:
- `latest`: latest stable release (includes all patch updates)
- `x.y.z` / `x.y` / `x`: specific versions
- `master`: latest build from the master branch (unchanged)

## Expected behavior after merge

| Event | Docker tags pushed |
|---|---|
| Push on `v1.11.0` tag | `1.11.0`, `1.11`, `1`, `latest` |
| Push on `master` | `master` |
| Push on `feature/**` | branch name |
| Pull request | no push |

Fixes #1663