### PR TITLE
docs: add HP DeskJet Ink Advantage 4530 to supported devices

### DIFF
--- a/SUPPORTED_DEVICES.md
+++ b/SUPPORTED_DEVICES.md
@@ -21,6 +21,7 @@ Users have reported successful scans with these devices:
 - HP DeskJet 3775
 - HP DeskJet 4670
 - HP DeskJet 5525
+- HP DeskJet Ink Advantage 4530 All-in-One Printer series
 - HP Envy 4504
 - HP Envy 4520
 - HP Envy 5530


### PR DESCRIPTION
## Summary

Adds the **HP DeskJet Ink Advantage 4530 All-in-One Printer series** to the supported devices list (Community Reports), as reported in #1663.

**Device report details (from the reporter):**
- Model: HP DeskJet Ink Advantage 4530 All-in-One Printer series
- Connection: Docker (Compose / Portainer)
- Command tested: `listen`
- Output format: PDF (SavePDF shortcut)
- Features verified: emulated duplex (page-wise mode), WalkupScanToComp with multiple destinations, platen scanning
- Nothing reported as not working

Fixes #1663