### PR TITLE
feat: configurable ToneMap settings via tone_map config

### DIFF
--- a/src/hpModels/EsclScanCaps.ts
+++ b/src/hpModels/EsclScanCaps.ts
@@ -4,6 +4,13 @@ import { parseXmlString } from "./ParseXmlString.js";
 
 import type { IScanCaps } from "../IScanCaps.js";
 //     this.data["scan:ScannerCapabilities"]["scan:Adf"]["0"]["scan:AdfSimplexInputCaps"]["0"]["scan:MaxWidth"]["0"]
+export interface TransformSupport {
+  "scan:Min": string[];
+  "scan:Max": string[];
+  "scan:Normal"?: string[];
+  "scan:Step"?: string[];
+}
+
 export interface EsclScanCapsData {
   "scan:ScannerCapabilities": {
     "scan:Platen": {
@@ -25,7 +32,23 @@ export interface EsclScanCapsData {
         "scan:AdfOption": string[];
       }[];
     }[];
+    "scan:BrightnessSupport"?: TransformSupport[];
+    "scan:ContrastSupport"?: TransformSupport[];
+    "scan:GammaSupport"?: TransformSupport[];
+    "scan:HighlightSupport"?: TransformSupport[];
+    "scan:ShadowSupport"?: TransformSupport[];
+    "scan:ThresholdSupport"?: TransformSupport[];
   };
+}
+
+export type ScanTransformName =
+  "Brightness" | "Contrast" | "Gamma" | "Highlight" | "Shadow" | "Threshold";
+
+export interface ScanTransformRange {
+  min: number;
+  max: number;
+  normal?: number | undefined;
+  step?: number | undefined;
 }
 
 export default class EsclScanCaps implements IScanCaps {
@@ -38,6 +61,26 @@ export default class EsclScanCaps implements IScanCaps {
   static async createScanCaps(content: string): Promise<EsclScanCaps> {
     const parsed = await parseXmlString<EsclScanCapsData>(content);
     return new EsclScanCaps(parsed);
+  }
+
+  getTransformRange(name: ScanTransformName): ScanTransformRange | null {
+    const key = `scan:${name}Support` as const;
+    const support = this.data["scan:ScannerCapabilities"][key]?.[0];
+    if (support === undefined) {
+      return null;
+    }
+    return {
+      min: Number.parseInt(support["scan:Min"][0], 10),
+      max: Number.parseInt(support["scan:Max"][0], 10),
+      normal:
+        support["scan:Normal"]?.[0] !== undefined
+          ? Number.parseInt(support["scan:Normal"][0], 10)
+          : undefined,
+      step:
+        support["scan:Step"]?.[0] !== undefined
+          ? Number.parseInt(support["scan:Step"][0], 10)
+          : undefined,
+    };
   }
 
   get platenMaxWidth(): number | null {

--- a/src/hpModels/EsclScanJobSettings.ts
+++ b/src/hpModels/EsclScanJobSettings.ts
@@ -4,6 +4,9 @@ import { parseXmlString } from "./ParseXmlString.js";
 import type { IScanJobSettings } from "./IScanJobSettings.js";
 import { ScanMode } from "../type/scanMode.js";
 import type { ImageFormat } from "../imageFormats/index.js";
+import type { ToneMap } from "../type/scanConfigs.js";
+import type EsclScanCaps from "./EsclScanCaps.js";
+import type { ScanTransformName } from "./EsclScanCaps.js";
 
 export enum DocumentFormatExt {
   Jpeg = "image/jpeg",
@@ -20,6 +23,8 @@ export default class EsclScanJobSettings implements IScanJobSettings {
   private readonly height: number | null;
   private readonly isDuplex: boolean;
   private readonly _format: ImageFormat;
+  private readonly toneMap: ToneMap | undefined;
+  private readonly scanCaps: EsclScanCaps | undefined;
 
   constructor(
     inputSource: InputSource,
@@ -30,6 +35,8 @@ export default class EsclScanJobSettings implements IScanJobSettings {
     width: number | null,
     height: number | null,
     isDuplex: boolean,
+    toneMap?: ToneMap,
+    scanCaps?: EsclScanCaps,
   ) {
     this.inputSource = inputSource;
     this.contentType = contentType;
@@ -39,6 +46,8 @@ export default class EsclScanJobSettings implements IScanJobSettings {
     this.width = width;
     this.height = height;
     this.isDuplex = isDuplex;
+    this.toneMap = toneMap;
+    this.scanCaps = scanCaps;
   }
 
   async toXML(): Promise<string> {
@@ -118,7 +127,18 @@ export default class EsclScanJobSettings implements IScanJobSettings {
 
     if (this.mode === ScanMode.Lineart) {
       parsed.ScanSettings.ColorMode = "BlackAndWhite1";
-      parsed.ScanSettings.Threshold = 128;
+      const rawThreshold = this.toneMap?.threshold ?? 128;
+      const thresholdRange = this.scanCaps?.getTransformRange("Threshold");
+      if (thresholdRange === undefined) {
+        parsed.ScanSettings.Threshold = rawThreshold;
+      } else if (thresholdRange === null) {
+        delete parsed.ScanSettings.Threshold;
+      } else {
+        parsed.ScanSettings.Threshold = Math.min(
+          Math.max(rawThreshold, thresholdRange.min),
+          thresholdRange.max,
+        );
+      }
     } else if (this.mode === ScanMode.Gray) {
       parsed.ScanSettings.ColorMode = "Grayscale8";
     } else {
@@ -153,6 +173,41 @@ export default class EsclScanJobSettings implements IScanJobSettings {
     }
 
     parsed.ScanSettings.Duplex = this.isDuplex;
+
+    const transformDefaults: Record<
+      Exclude<ScanTransformName, "Threshold">,
+      number
+    > = {
+      Brightness: 996,
+      Contrast: 996,
+      Gamma: 180,
+      Highlight: 1396,
+      Shadow: 70,
+    };
+
+    const applyTransform = (
+      name: Exclude<ScanTransformName, "Threshold">,
+      configured: number | undefined,
+    ) => {
+      const range = this.scanCaps?.getTransformRange(name);
+      const raw = configured ?? transformDefaults[name];
+      if (range === undefined) {
+        parsed.ScanSettings[name] = raw;
+      } else if (range === null) {
+        delete parsed.ScanSettings[name];
+      } else {
+        parsed.ScanSettings[name] = Math.min(
+          Math.max(raw, range.min),
+          range.max,
+        );
+      }
+    };
+
+    applyTransform("Brightness", this.toneMap?.brightness);
+    applyTransform("Contrast", this.toneMap?.contrast);
+    applyTransform("Gamma", this.toneMap?.gamma);
+    applyTransform("Highlight", this.toneMap?.highlight);
+    applyTransform("Shadow", this.toneMap?.shadow);
 
     const builder = new xml2js.Builder({
       xmldec: { version: "1.0", encoding: "UTF-8" },

--- a/src/hpModels/ScanJobSettings.ts
+++ b/src/hpModels/ScanJobSettings.ts
@@ -5,6 +5,7 @@ import type { IScanJobSettings } from "./IScanJobSettings.js";
 import { ScanMode } from "../type/scanMode.js";
 import type ScanCaps from "./ScanCaps.js";
 import type { ImageFormat } from "../imageFormats/index.js";
+import type { ToneMap } from "../type/scanConfigs.js";
 
 export enum DeviceFormat {
   Jpeg = "Jpeg",
@@ -21,6 +22,7 @@ export default class ScanJobSettings implements IScanJobSettings {
   private readonly isDuplex: boolean;
   private readonly _format: ImageFormat;
   private readonly scanCaps: ScanCaps;
+  private readonly toneMap: ToneMap | undefined;
 
   constructor(
     inputSource: InputSource,
@@ -32,6 +34,7 @@ export default class ScanJobSettings implements IScanJobSettings {
     height: number | null,
     isDuplex: boolean,
     scanCaps: ScanCaps,
+    toneMap?: ToneMap,
   ) {
     this.inputSource = inputSource;
     this.contentType = contentType;
@@ -42,6 +45,7 @@ export default class ScanJobSettings implements IScanJobSettings {
     this.height = height;
     this.isDuplex = isDuplex;
     this.scanCaps = scanCaps;
+    this.toneMap = toneMap;
   }
 
   toJSON() {
@@ -106,7 +110,16 @@ export default class ScanJobSettings implements IScanJobSettings {
         YResolution: number[];
         ColorSpace: string[];
         BitDepth: number[];
-        ToneMap: [{ Threshold: number[] }];
+        ToneMap: [
+          {
+            Gamma: number[];
+            Brightness: number[];
+            Contrast: number[];
+            Highlite: number[];
+            Shadow: number[];
+            Threshold: number[];
+          },
+        ];
         AdfOptions?: [{ AdfOption: ["Duplex"] }];
         ContentType: string[];
       };
@@ -129,6 +142,26 @@ export default class ScanJobSettings implements IScanJobSettings {
       parsed.ScanSettings.BitDepth = [1];
       parsed.ScanSettings.ToneMap[0].Threshold[0] = 128;
       colorType = "K1";
+    }
+
+    const toneMap = this.toneMap;
+    if (toneMap?.gamma !== undefined) {
+      parsed.ScanSettings.ToneMap[0].Gamma[0] = toneMap.gamma;
+    }
+    if (toneMap?.brightness !== undefined) {
+      parsed.ScanSettings.ToneMap[0].Brightness[0] = toneMap.brightness;
+    }
+    if (toneMap?.contrast !== undefined) {
+      parsed.ScanSettings.ToneMap[0].Contrast[0] = toneMap.contrast;
+    }
+    if (toneMap?.highlight !== undefined) {
+      parsed.ScanSettings.ToneMap[0].Highlite[0] = toneMap.highlight;
+    }
+    if (toneMap?.shadow !== undefined) {
+      parsed.ScanSettings.ToneMap[0].Shadow[0] = toneMap.shadow;
+    }
+    if (toneMap?.threshold !== undefined) {
+      parsed.ScanSettings.ToneMap[0].Threshold[0] = toneMap.threshold;
     }
 
     const deviceFormat = this.format.getDeviceFormat();

--- a/src/program.ts
+++ b/src/program.ts
@@ -545,6 +545,7 @@ function getScanConfiguration(
     paperlessConfig,
     nextcloudConfig,
     preferEscl,
+    ...(fileConfig.tone_map !== undefined && { toneMap: fileConfig.tone_map }),
   };
   return scanConfig;
 }

--- a/src/readDeviceCapabilities.ts
+++ b/src/readDeviceCapabilities.ts
@@ -11,6 +11,7 @@ import ScanJobSettings from "./hpModels/ScanJobSettings.js";
 import type { ScanMode } from "./type/scanMode.js";
 import type { ImageFormat } from "./imageFormats/index.js";
 import type { IScanCaps } from "./IScanCaps.js";
+import type { ToneMap } from "./type/scanConfigs.js";
 
 async function getScanCaps(
   api: DeviceClient,
@@ -115,6 +116,7 @@ export async function readDeviceCapabilities(
     width: number | null,
     height: number | null,
     isDuplex: boolean,
+    toneMap?: ToneMap,
   ): IScanJobSettings => {
     let scanJobSettings: IScanJobSettings;
     if (scanCaps?.isEscl === true) {
@@ -127,6 +129,8 @@ export async function readDeviceCapabilities(
         width,
         height,
         isDuplex,
+        toneMap,
+        scanCaps as EsclScanCaps,
       );
     } else {
       scanJobSettings = new ScanJobSettings(
@@ -139,6 +143,7 @@ export async function readDeviceCapabilities(
         height,
         isDuplex,
         scanCaps as ScanCaps,
+        toneMap,
       );
     }
     return scanJobSettings;

--- a/src/scanProcessing.ts
+++ b/src/scanProcessing.ts
@@ -137,6 +137,7 @@ export async function saveScanFromEvent(
     scanWidth,
     scanHeight,
     isDuplex,
+    scanConfig.toneMap,
   );
 
   const scanJobContent: ScanContent = { elements: [] };
@@ -199,6 +200,7 @@ export async function scanFromAdf(
     effectiveScanWidth,
     effectiveScanHeight,
     adfAutoScanConfig.isDuplex,
+    adfAutoScanConfig.toneMap,
   );
 
   const scanJobContent: ScanContent = { elements: [] };
@@ -284,6 +286,7 @@ export async function singleScan(
     scanWidth,
     scanHeight,
     scanConfig.isDuplex,
+    scanConfig.toneMap,
   );
 
   const scanJobContent: ScanContent = { elements: [] };

--- a/src/type/DeviceCapabilities.ts
+++ b/src/type/DeviceCapabilities.ts
@@ -3,6 +3,7 @@ import type { IScanJobSettings } from "../hpModels/IScanJobSettings.js";
 import type { InputSource } from "./InputSource.js";
 import type { ScanMode } from "./scanMode.js";
 import type { ImageFormat } from "../imageFormats/index.js";
+import type { ToneMap } from "./scanConfigs.js";
 
 export interface DeviceCapabilities {
   supportsMultiItemScanFromPlaten: boolean;
@@ -27,6 +28,7 @@ export interface DeviceCapabilities {
     width: number | null,
     height: number | null,
     isDuplex: boolean,
+    toneMap?: ToneMap,
   ) => IScanJobSettings;
   submitScanJob: (scanJobSettings: IScanJobSettings) => Promise<string>;
 }

--- a/src/type/FileConfig.ts
+++ b/src/type/FileConfig.ts
@@ -70,6 +70,24 @@ export const configSchema = z
     paper_orientation: z.enum(["portrait", "landscape"]).optional(), // Applied to paper_size only
     paper_dim: z.string().optional(), // Custom paper dimensions (e.g., "21x29.7cm", "8.5x11in")
 
+    ///
+    /// Tone Map (image transforms: gamma, brightness, contrast, ...)
+    ///
+    // Raw protocol values. Ranges are device-specific: for eSCL devices the
+    // values are clamped to the device's advertised Min/Max (see XxxSupport),
+    // while legacy (LEDM) devices expose no ranges and values are sent as-is.
+    tone_map: z
+      .object({
+        gamma: z.number().int().optional(),
+        brightness: z.number().int().optional(),
+        contrast: z.number().int().optional(),
+        highlight: z.number().int().optional(),
+        shadow: z.number().int().optional(),
+        threshold: z.number().int().optional(),
+      })
+      .strict()
+      .optional(),
+
     prefer_escl: z.boolean().optional(), // Always upload scans as PDF
 
     ///

--- a/src/type/scanConfigs.ts
+++ b/src/type/scanConfigs.ts
@@ -4,6 +4,15 @@ import type { NextcloudConfig } from "../nextcloud/NextcloudConfig.js";
 import type { ScanMode } from "./scanMode.js";
 import type { ScanFormat } from "./scanFormat.js";
 
+export interface ToneMap {
+  gamma?: number | undefined;
+  brightness?: number | undefined;
+  contrast?: number | undefined;
+  highlight?: number | undefined;
+  shadow?: number | undefined;
+  threshold?: number | undefined;
+}
+
 export interface ScanConfig {
   resolution: number;
   mode: ScanMode;
@@ -17,6 +26,7 @@ export interface ScanConfig {
   paperSize: string | undefined; // e.g., "A4", "Letter", "Max", or preset name
   paperDim: string | undefined; // e.g., "21x29.7cm", "8.5x11in", "210x297mm"
   paperOrientation: "portrait" | "landscape" | undefined;
+  toneMap?: ToneMap;
 }
 export type AdfAutoScanConfig = ScanConfig & {
   isDuplex: boolean;

--- a/test/ScanJobSettings.test.ts
+++ b/test/ScanJobSettings.test.ts
@@ -111,5 +111,35 @@ describe("ScanJobSettings", () => {
         content.trimEnd().replace(/\r\n/g, "\n"),
       );
     });
+
+    it("Allows to override the tone map", async () => {
+      const scanJobSettings = new ScanJobSettings(
+        InputSource.Adf,
+        "Document",
+        createImageFormat(ScanFormat.Jpeg),
+        200,
+        ScanMode.Color,
+        null,
+        null,
+        false,
+        scanCaps,
+        {
+          gamma: 900,
+          brightness: 1100,
+          contrast: 1200,
+          highlight: 200,
+          shadow: 30,
+          threshold: 150,
+        },
+      );
+
+      const xml = await scanJobSettings.toXML();
+      expect(xml).to.contain("<Gamma>900</Gamma>");
+      expect(xml).to.contain("<Brightness>1100</Brightness>");
+      expect(xml).to.contain("<Contrast>1200</Contrast>");
+      expect(xml).to.contain("<Highlite>200</Highlite>");
+      expect(xml).to.contain("<Shadow>30</Shadow>");
+      expect(xml).to.contain("<Threshold>150</Threshold>");
+    });
   });
 });

--- a/test/eSCL_ScanJobSettings.test.ts
+++ b/test/eSCL_ScanJobSettings.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import * as fs from "node:fs/promises";
 import { InputSource } from "../src/type/InputSource.js";
 import EsclScanJobSettings from "../src/hpModels/EsclScanJobSettings.js";
+import EsclScanCaps from "../src/hpModels/EsclScanCaps.js";
 import { ScanMode } from "../src/type/scanMode.js";
 import { ScanFormat } from "../src/type/scanFormat.js";
 
@@ -53,6 +54,94 @@ describe("ScanJobSettings", () => {
       expect((await scanJobSettings.toXML()).trimEnd()).to.be.eq(
         content.trimEnd().replace(/\r\n/g, "\n"),
       );
+    });
+    it("Allows to override the tone map (passthrough without caps)", async () => {
+      const scanJobSettings = new EsclScanJobSettings(
+        InputSource.Platen,
+        "Document",
+        createImageFormat(ScanFormat.Jpeg),
+        200,
+        ScanMode.Color,
+        null,
+        null,
+        false,
+        {
+          brightness: 1500,
+          contrast: 500,
+          gamma: 200,
+          highlight: 1200,
+          shadow: 100,
+        },
+      );
+
+      const xml = await scanJobSettings.toXML();
+      expect(xml).to.contain("<Brightness>1500</Brightness>");
+      expect(xml).to.contain("<Contrast>500</Contrast>");
+      expect(xml).to.contain("<Gamma>200</Gamma>");
+      expect(xml).to.contain("<Highlight>1200</Highlight>");
+      expect(xml).to.contain("<Shadow>100</Shadow>");
+    });
+    it("Clamps tone map to device ranges and omits unsupported transforms", async () => {
+      const capsContent: string = await fs.readFile(
+        path.resolve(__dirname, "./asset/eSCL_ScannerCapabilities_Simplex.xml"),
+        { encoding: "utf8" },
+      );
+      const scanCaps = await EsclScanCaps.createScanCaps(capsContent);
+
+      const scanJobSettings = new EsclScanJobSettings(
+        InputSource.Adf,
+        "Document",
+        createImageFormat(ScanFormat.Jpeg),
+        200,
+        ScanMode.Color,
+        null,
+        null,
+        true,
+        {
+          brightness: 2500,
+          contrast: -10,
+          gamma: 9999,
+          highlight: 9999,
+          shadow: 9999,
+        },
+        scanCaps,
+      );
+
+      const xml = await scanJobSettings.toXML();
+      expect(xml).to.contain("<Brightness>2000</Brightness>");
+      expect(xml).to.contain("<Contrast>0</Contrast>");
+      expect(xml).not.to.contain("<Gamma>");
+      expect(xml).not.to.contain("<Highlight>");
+      expect(xml).not.to.contain("<Shadow>");
+    });
+    it("Clamps tone map values for a device supporting all transforms", async () => {
+      const capsContent: string = await fs.readFile(
+        path.resolve(__dirname, "./asset/eSCL_ScannerCapabilities_Duplex.xml"),
+        { encoding: "utf8" },
+      );
+      const scanCaps = await EsclScanCaps.createScanCaps(capsContent);
+
+      const scanJobSettings = new EsclScanJobSettings(
+        InputSource.Adf,
+        "Document",
+        createImageFormat(ScanFormat.Jpeg),
+        200,
+        ScanMode.Color,
+        null,
+        null,
+        true,
+        {
+          gamma: 1000,
+          highlight: 3000,
+          shadow: 2500,
+        },
+        scanCaps,
+      );
+
+      const xml = await scanJobSettings.toXML();
+      expect(xml).to.contain("<Gamma>400</Gamma>");
+      expect(xml).to.contain("<Highlight>2000</Highlight>");
+      expect(xml).to.contain("<Shadow>2000</Shadow>");
     });
   });
 });


### PR DESCRIPTION
Closes #1611

## Summary

Make the ToneMap scan settings (gamma, brightness, contrast, highlight, shadow, threshold) configurable through an optional `tone_map` section in the config file, instead of relying on hardcoded values.

## Proposed Changes

### 1. Configuration

A new optional `tone_map` section in the config file:

```json
{
  "tone_map": {
    "gamma": 1000,
    "brightness": 1000,
    "contrast": 1000,
    "highlight": 179,
    "shadow": 25,
    "threshold": 128
  }
}
```

All fields are optional; unset fields keep the current per-protocol defaults.

### 2. LEDM devices

Values are injected into the `<ToneMap>` element of the scan job (`ScanJobSettings.toXML()`), keeping the legacy `Highlite` element name.

### 3. eSCL devices

Values are clamped to the device's advertised ranges (`XxxSupport` Min/Max) parsed from `ScannerCapabilities`. Transforms the device does not advertise (e.g. Gamma/Highlight/Shadow on the Smart Tank 570) are now **omitted** from the job instead of being sent blindly.

## Notes

- Raw protocol values (pass-through semantics): LEDM exposes no ranges, so values are sent as-is; eSCL values are validated/clamped against the connected device.
- The previous implementation (PR #1612) was lost in a master history rewrite; this is a fresh implementation on the current master.