### PR TITLE
feat(windows): installer overhaul - manual IP config, branding, signing CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ permissions:
   contents: write
   id-token: write
   attestations: write
+  actions: read
 
 jobs:
   npm:
@@ -38,6 +39,9 @@ jobs:
   binaries:
     name: Binaries and packages
     runs-on: ubuntu-latest
+    env:
+      SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+      SIGNPATH_SIGNING_POLICY_SLUG: ${{ startsWith(github.ref, 'refs/tags/v') && 'release-signing' || 'test-signing' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -89,6 +93,34 @@ jobs:
           sudo apt-get update -qq && sudo apt-get install -y -qq nsis
           cd packaging/windows
           makensis -DVERSION="${{ steps.ver.outputs.version }}" installer.nsi
+
+      - name: Upload unsigned installer for SignPath
+        id: upload-unsigned-installer
+        if: env.SIGNPATH_API_TOKEN != ''
+        uses: actions/upload-artifact@v4
+        with:
+          path: release/setup-node-hp-scan-to-v${{ steps.ver.outputs.version }}.exe
+          if-no-files-found: error
+          archive: false
+
+      - name: Sign installer with SignPath
+        if: env.SIGNPATH_API_TOKEN != ''
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ env.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG || 'node-hp-scan-to' }}
+          signing-policy-slug: ${{ env.SIGNPATH_SIGNING_POLICY_SLUG }}
+          github-artifact-id: ${{ steps.upload-unsigned-installer.outputs.artifact-id }}
+          wait-for-completion: true
+          wait-for-completion-timeout-in-seconds: 1800
+          skip-decompress: true
+          output-artifact-directory: release-signed
+
+      - name: Move signed installer into place
+        if: env.SIGNPATH_API_TOKEN != ''
+        run: |
+          mv release-signed/setup-node-hp-scan-to-*.exe release/
 
       - name: Generate checksums
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,16 @@ jobs:
           find . -maxdepth 1 -type f ! -name SHA256SUMS.txt -printf '%f\0' |
             xargs -0 sha256sum > SHA256SUMS.txt
 
+      - name: Upload installer for manual testing
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-installer-test
+          path: |
+            release/setup-node-hp-scan-to-*.exe
+            release/SHA256SUMS.txt
+          if-no-files-found: error
+
       - name: Generate SBOM
         uses: anchore/sbom-action@v0.23.1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Upload unsigned installer for SignPath
         id: upload-unsigned-installer
         if: env.SIGNPATH_API_TOKEN != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: release/setup-node-hp-scan-to-v${{ steps.ver.outputs.version }}.exe
           if-no-files-found: error

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -158,7 +158,7 @@ Function ModePageCreate
 
   !insertmacro MUI_HEADER_TEXT \
     "Choose installation type" \
-    "How should HP Scan to Computer be installed?"
+    "How should node-hp-scan-to be installed?"
 
   nsDialogs::Create 1018
   Pop $0

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -57,8 +57,10 @@ Var DevIp
 Var DeviceRaw         ; raw stdout of the discover run
 Var DeviceCount       ; number of parsed devices
 Var DiscDir           ; LOCALAPPDATA dir hosting the discovery binary
+Var OldOut            ; saved output dir around the discovery extraction
 Var ComboDevice       ; dropdown with discovered printers (when > 0)
 Var EditLogPath       ; read-only text showing the diagnostic log path
+Var LogPath           ; actual path of the diagnostic log file
 Var Status            ; outcome of the discovery, shown at the top of the page
 Var RadioByName
 Var RadioByIp
@@ -214,6 +216,10 @@ Function ModePageLeave
       Quit
     ${EndIf}
   ${EndIf}
+
+  ; network detection starts now (device page does the blocking work);
+  ; show the banner before the page transition so there is no dead time
+  Banner::show "Searching your network for printers, please wait..."
 FunctionEnd
 
 ; ---------------------------------------------------------------------------
@@ -347,33 +353,24 @@ Function _RunDiscovery
   ; allow the user profile, so discovery keeps working on such hosts.
   StrCpy $DiscDir "$LOCALAPPDATA\node-hp-scan-to-setup"
   CreateDirectory "$DiscDir"
-  ; use a private extraction dir to avoid clobbering a running instance
+  ; File writes to the current output dir; restore it afterwards so later
+  ; install/uninstall File instructions still land in $INSTDIR
+  StrCpy $OldOut "$OUTDIR"
   SetOutPath "$DiscDir"
   File "/oname=node-hp-scan-to.exe" "staging\node-hp-scan-to.exe"
+  SetOutPath "$OldOut"
   Call _FwDiscoveryAllow
+  ; cold mDNS cache: first browse sometimes finds nothing, so retry once
+  ; with a longer window before giving up
   nsExec::ExecToStack '"$DiscDir\node-hp-scan-to.exe" discover --timeout 5'
-  Call _FwDiscoveryRemove
-FunctionEnd
-
-; read a whole text file onto the stack (path in, contents out)
-Function _SlurpFile
-  Pop $R8
-  ClearErrors
-  FileOpen $R7 "$R8" r
-  ${If} ${Errors}
-    Push ""
-    Return
+  Pop $R0
+  Pop $DeviceRaw
+  ${If} $R0 != 0
+    nsExec::ExecToStack '"$DiscDir\node-hp-scan-to.exe" discover --timeout 8'
+    Pop $R0
+    Pop $DeviceRaw
   ${EndIf}
-  StrCpy $R9 ""
-  ${Do}
-    FileRead $R7 $R6
-    ${If} ${Errors}
-      ${Break}
-    ${EndIf}
-    StrCpy $R9 "$R9$R6"
-  ${Loop}
-  FileClose $R7
-  Push $R9
+  Call _FwDiscoveryRemove
 FunctionEnd
 
 Function DevicePageCreate
@@ -381,22 +378,18 @@ Function DevicePageCreate
     "Select your printer" \
     "The printer can be located by name (recommended) or by fixed IP address."
 
-  ; inform the user before the (blocking) discovery - no empty wizard page
-  Banner::show "Searching your network for printers...$\nThis can take up to 15 seconds."
-
   Call _RunDiscovery
-  Pop $R0                       ; exit code
-  Pop $DeviceRaw                ; stdout (line echoes from the binary)
+  ; $R0 and $DeviceRaw are set by _RunDiscovery (first or retry attempt)
 
   Banner::destroy
 
   ; on failure or empty result, persist diagnostics the user can open/copy
-  StrCpy $EditLogPath "$TEMP\node-hp-scan-to-discovery.log"
+  StrCpy $LogPath "$TEMP\node-hp-scan-to-discovery.log"
   ${If} $R0 == 0
     Call _ParseDevices
   ${Else}
     StrCpy $DeviceCount 0
-    FileOpen $0 "$EditLogPath" w
+    FileOpen $0 "$LogPath" w
     FileWrite $0 "exit code: $R0$\r$\n"
     FileWrite $0 "--- stdout ---$\r$\n"
     FileWrite $0 "$DeviceRaw$\r$\n"
@@ -407,12 +400,8 @@ Function DevicePageCreate
   nsDialogs::Create 1018
   Pop $0
 
-  ${NSD_CreateLabel} 0 0 100% 16u \
-    "Select how node-hp-scan-to finds your printer, then continue."
-  Pop $0
-
   ; result / status line
-  ${NSD_CreateLabel} 8u 18u 96% 20u "placeholder"
+  ${NSD_CreateLabel} 0 0 100% 16u "placeholder"
   Pop $Status
   ${If} $R0 == 0
     ${If} $DeviceCount == 0
@@ -428,9 +417,9 @@ Function DevicePageCreate
   ${EndIf}
 
   ; printer dropdown (only when at least one device was found)
-  ${NSD_CreateLabel} 0 42u 100% 10u "Printer:"
+  ${NSD_CreateLabel} 0 16u 100% 10u "Printer:"
   Pop $0
-  ${NSD_CreateDropList} 0 52u 100% 90u ""
+  ${NSD_CreateDropList} 0 26u 100% 10u ""
   Pop $ComboDevice
   ${If} $DeviceCount > 0
     ; add every "display" from the parser ini (ip|name (ip))
@@ -455,41 +444,43 @@ Function DevicePageCreate
   ${EndIf}
 
   ; how to reach the printer
-  ${NSD_CreateRadioButton} 8u 64u 90% 10u \
+  ${NSD_CreateRadioButton} 8u 40u 90% 10u \
     "Use the selected printer by name (recommended)"
   Pop $RadioByName
   ${NSD_AddStyle} $RadioByName ${WS_GROUP}
   ${NSD_SetState} $RadioByName ${BST_CHECKED}
 
-  ${NSD_CreateRadioButton} 8u 76u 60% 10u \
-    "Pin by IP address instead"
+  ${NSD_CreateRadioButton} 8u 51u 55% 10u \
+    "Pin by IP address instead:"
   Pop $RadioByIp
-  ${NSD_CreateText} 68% 76u 28% 12u ""
+  ${NSD_CreateText} 60% 51u 36% 12u ""
   Pop $EditIp
 
-  ${NSD_CreateRadioButton} 8u 90u 90% 10u \
+  ${NSD_CreateRadioButton} 8u 64u 55% 10u \
     "Enter it manually (name or IP):"
   Pop $RadioOther
   ${NSD_OnClick} $RadioOther OnOtherClick
-  ${NSD_CreateText} 0 100u 100% 12u ""
+  ${NSD_CreateText} 60% 64u 36% 12u ""
   Pop $EditOther
   !insertmacro _CtrlEnable $EditOther 0
 
-  ${NSD_CreateRadioButton} 8u 112u 90% 10u \
+  ${NSD_CreateRadioButton} 8u 77u 90% 10u \
     "Configure later (you will edit config\\default.json yourself)"
   Pop $RadioLater
   ${NSD_AddStyle} $RadioLater ${WS_GROUP}
 
   ; diagnostics: selectable log path + an "open folder" button
-  ${NSD_CreateLabel} 0 126u 100% 8u "Diagnostics (kept only on failure):"
+  ${NSD_CreateLabel} 0 89u 100% 8u "Diagnostics (kept only on failure):"
   Pop $0
-  ${NSD_CreateText} 0 134u 78% 12u ""
+  ${NSD_CreateText} 0 97u 76% 12u ""
   Pop $EditLogPath
-  ${NSD_SetText} $EditLogPath "$TEMP\node-hp-scan-to-discovery.log"
-  ${NSD_CreateButton} 80% 134u 18% 12u "Open folder"
+  ${NSD_AddStyle} $EditLogPath "${ES_READONLY}"
+  ${NSD_SetText} $EditLogPath "$LogPath"
+  ${NSD_CreateButton} 78% 97u 20% 12u "Open folder"
   Pop $0
   ${NSD_OnClick} $0 BrowseLogs
 
+  ; compact everything vertically so it fits the wizard pane (~115u tall)
   ${If} $DeviceCount == 0
     ; no printers: the dropdown is useless, disable it and "by name"
     System::Call "user32::EnableWindow(p$ComboDevice, i0)"
@@ -501,8 +492,8 @@ Function DevicePageCreate
 FunctionEnd
 
 Function BrowseLogs
-  ${If} ${FileExists} "$EditLogPath"
-    ExecShell "open" "explorer.exe" "/select,$EditLogPath"
+  ${If} ${FileExists} "$LogPath"
+    ExecShell "open" "explorer.exe" "/select,$LogPath"
   ${Else}
     MessageBox MB_OK|MB_ICONINFORMATION "No diagnostic log was written (discovery succeeded)."
   ${EndIf}

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -520,7 +520,7 @@ Function DevicePageLeave
       Abort
     ${EndIf}
     Call _FwDiscoveryAllow
-    nsExec::ExecToStack '"$PLUGINSDIR\node-hp-scan-to.exe" discover --timeout 4 --ip "$DevIp"'
+    nsExec::ExecToStack '"$DiscDir\node-hp-scan-to.exe" discover --timeout 4 --ip "$DevIp"'
     Call _FwDiscoveryRemove
     Pop $0
     Pop $R1                       ; discard captured stdout
@@ -558,12 +558,12 @@ Function DevicePageLeave
       StrCpy $DeviceChoice "ip"
       StrCpy $DevIp "$DevName"
       Call _FwDiscoveryAllow
-      nsExec::ExecToStack '"$PLUGINSDIR\node-hp-scan-to.exe" discover --timeout 4 --ip "$DevIp"'
+nsExec::ExecToStack '"$DiscDir\node-hp-scan-to.exe" discover --timeout 4 --ip "$DevIp"'
       Call _FwDiscoveryRemove
     ${Else}
       StrCpy $DeviceChoice "name"
       Call _FwDiscoveryAllow
-      nsExec::ExecToStack '"$PLUGINSDIR\node-hp-scan-to.exe" discover --timeout 4 --name "$DevName"'
+      nsExec::ExecToStack '"$DiscDir\node-hp-scan-to.exe" discover --timeout 4 --name "$DevName"'
       Call _FwDiscoveryRemove
     ${EndIf}
     Pop $0

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -36,7 +36,6 @@ InstallDir "$LOCALAPPDATA\Programs\${APPNAME}"
 !include "StrFunc.nsh"
 
 ${StrRep}
-${StrLoc}
 
 
 !ifndef WS_GROUP
@@ -51,23 +50,13 @@ Var RadioUser
 Var RadioSystem
 
 ; device selection page state
-Var DeviceChoice      ; "name" | "ip" | "skip"
-Var DevName
+Var DeviceChoice      ; "skip" | "ip"
 Var DevIp
-Var DeviceRaw         ; raw stdout of the discover run
-Var DeviceCount       ; number of parsed devices
-Var DiscDir           ; LOCALAPPDATA dir hosting the discovery binary
-Var OldOut            ; saved output dir around the discovery extraction
-Var ComboDevice       ; dropdown with discovered printers (when > 0)
-Var EditLogPath       ; read-only text showing the diagnostic log path
-Var LogPath           ; actual path of the diagnostic log file
-Var Status            ; outcome of the discovery, shown at the top of the page
-Var RadioByName
-Var RadioByIp
-Var RadioOther
-Var RadioLater
-Var EditOther
+Var DevLabel
 Var EditIp
+Var EditLabel
+Var RadioLater
+Var RadioLater2
 
 ; startup behaviour
 Var RunArgs           ; arguments passed to node-hp-scan-to at boot
@@ -144,7 +133,6 @@ Function .onInit
     StrCpy $CmdlineSystemMode "1"
   ${EndIf}
   StrCpy $DeviceChoice "skip"
-  StrCpy $DevName ""
   StrCpy $DevIp ""
   StrCpy $RunArgs "listen --health-check"
   ; /ADF switches the startup behaviour in silent installs
@@ -216,10 +204,6 @@ Function ModePageLeave
       Quit
     ${EndIf}
   ${EndIf}
-
-  ; network detection starts now (device page does the blocking work);
-  ; show the banner before the page transition so there is no dead time
-  Banner::show "Searching your network for printers, please wait..."
 FunctionEnd
 
 ; ---------------------------------------------------------------------------
@@ -267,341 +251,73 @@ FunctionEnd
 ; ---------------------------------------------------------------------------
 ; device selection page
 
-!macro _CtrlEnable CTRL ENABLE
-  System::Call "user32::EnableWindow(p${CTRL}, i${ENABLE})"
-!macroend
-
-; The compiled binary listens for mDNS answers, which trips the Windows
-; Firewall "allow access" dialog over the installer UI while nsExec waits -
-; experienced as a freeze, and skipping it silently kills discovery.
-; While elevated, whitelist the scratch copy for a moment; best effort only
-; (a non-elevated user install simply keeps the native prompt).
-!define FW_TEMP_RULE "node-hp-scan-to-setup-discovery"
-
-Function _FwDiscoveryAllow
-  nsExec::Exec 'netsh advfirewall firewall delete rule name="${FW_TEMP_RULE}"'
-  Pop $0
-  nsExec::Exec 'netsh advfirewall firewall add rule name="${FW_TEMP_RULE}" dir=in action=allow program="$DiscDir\node-hp-scan-to.exe" enable=yes profile=private'
-  Pop $0
-FunctionEnd
-
-Function _FwDiscoveryRemove
-  nsExec::Exec 'netsh advfirewall firewall delete rule name="${FW_TEMP_RULE}"'
-  Pop $0
-FunctionEnd
-
-; parse $DeviceRaw ("name\tip" lines, \r\n separated) into
-; $DiscDir\devices.ini ([d] <index> = <ip>|<display>) and set $DeviceCount
-Function _ParseDevices
-  StrCpy $DeviceCount 0
-  Delete "$DiscDir\devices.ini"
-  StrCpy $R2 "$DeviceRaw"
-  ${Do}
-    ${If} "$R2" == ""
-      ${Break}
-    ${EndIf}
-    ; cut the first line off (handle both \n and \r\n endings)
-    ${StrLoc} "$R3" "$R2" "$\n" "0"
-    ${If} "$R3" == ""
-      StrCpy $R1 "$R2"
-      StrCpy $R2 ""
-    ${Else}
-      ${If} $R3 > 0
-        StrCpy $R1 "$R2" $R3
-      ${Else}
-        StrCpy $R1 ""
-      ${EndIf}
-      IntOp $R4 "$R3" + 1
-      StrCpy $R2 "$R2" "" $R4
-    ${EndIf}
-    ${StrRep} "$R1" "$R1" "$\r" ""
-
-    ; split "name<TAB>ip", skip malformed lines
-    StrCpy $R9 0                  ; 1 = valid entry
-    ${StrLoc} "$R5" "$R1" "$\t" "0"
-    ${If} "$R5" != ""
-      ${If} $R5 > 0
-        StrCpy $R9 1
-        StrCpy $R6 "$R1" $R5      ; device name
-        IntOp $R7 "$R5" + 1
-        StrCpy $R8 "$R1" "" $R7   ; ip
-      ${EndIf}
-    ${EndIf}
-
-    ${If} $R9 == 1
-      WriteIniStr "$DiscDir\devices.ini" "d" "$DeviceCount" "$R8|$R6 ($R8)"
-      IntOp $DeviceCount "$DeviceCount" + 1
-    ${EndIf}
-  ${Loop}
-FunctionEnd
-
-Function OnOtherClick
-  ${NSD_GetState} $RadioOther $0
-  ${If} $0 == ${BST_CHECKED}
-    !insertmacro _CtrlEnable $EditOther 1
-  ${Else}
-    !insertmacro _CtrlEnable $EditOther 0
-  ${EndIf}
-FunctionEnd
-
-; -------------------------------------------------------------------
-; device selection page (synchronous discovery)
-
-Function _RunDiscovery
-  ; Extract to LOCALAPPDATA, not PLUGINSDIR (%TEMP%): WDAC/Device Guard
-  ; policies on managed machines typically block execution from Temp but
-  ; allow the user profile, so discovery keeps working on such hosts.
-  StrCpy $DiscDir "$LOCALAPPDATA\node-hp-scan-to-setup"
-  CreateDirectory "$DiscDir"
-  ; File writes to the current output dir; restore it afterwards so later
-  ; install/uninstall File instructions still land in $INSTDIR
-  StrCpy $OldOut "$OUTDIR"
-  SetOutPath "$DiscDir"
-  File "/oname=node-hp-scan-to.exe" "staging\node-hp-scan-to.exe"
-  SetOutPath "$OldOut"
-  Call _FwDiscoveryAllow
-  ; cold mDNS cache: first browse sometimes finds nothing, so retry once
-  ; with a longer window before giving up
-  nsExec::ExecToStack '"$DiscDir\node-hp-scan-to.exe" discover --timeout 5'
-  Pop $R0
-  Pop $DeviceRaw
-  ${If} $R0 != 0
-    nsExec::ExecToStack '"$DiscDir\node-hp-scan-to.exe" discover --timeout 8'
-    Pop $R0
-    Pop $DeviceRaw
-  ${EndIf}
-  Call _FwDiscoveryRemove
-FunctionEnd
+; ---------------------------------------------------------------------------
+; printer configuration page (manual IP entry - no network discovery)
 
 Function DevicePageCreate
   !insertmacro MUI_HEADER_TEXT \
-    "Select your printer" \
-    "The printer can be located by name (recommended) or by fixed IP address."
-
-  Call _RunDiscovery
-  ; $R0 and $DeviceRaw are set by _RunDiscovery (first or retry attempt)
-
-  Banner::destroy
-
-  ; on failure or empty result, persist diagnostics the user can open/copy
-  StrCpy $LogPath "$TEMP\node-hp-scan-to-discovery.log"
-  ${If} $R0 == 0
-    Call _ParseDevices
-  ${Else}
-    StrCpy $DeviceCount 0
-    FileOpen $0 "$LogPath" w
-    FileWrite $0 "exit code: $R0$\r$\n"
-    FileWrite $0 "--- stdout ---$\r$\n"
-    FileWrite $0 "$DeviceRaw$\r$\n"
-    FileWrite $0 "--- end ---$\r$\n"
-    FileClose $0
-  ${EndIf}
+    "Configure your printer" \
+    "IP address + destination name shown on the printer."
 
   nsDialogs::Create 1018
   Pop $0
 
-  ; result / status line
-  ${NSD_CreateLabel} 0 0 100% 16u "placeholder"
-  Pop $Status
-  ${If} $R0 == 0
-    ${If} $DeviceCount == 0
-      ${NSD_SetText} $Status "No scan-capable printer was detected."
-    ${ElseIf} $DeviceCount == 1
-      ${NSD_SetText} $Status "One printer was detected. Choose how to reach it below."
-    ${Else}
-      ${NSD_SetText} $Status "$DeviceCount printers were detected. Pick one in the list below."
-    ${EndIf}
-  ${Else}
-    ${NSD_SetText} $Status \
-      "Printer detection failed (code $R0). You can still configure a printer manually below."
-  ${EndIf}
-
-  ; printer dropdown (only when at least one device was found)
-  ${NSD_CreateLabel} 0 16u 100% 10u "Printer:"
+  ${NSD_CreateLabel} 0 0 100% 14u \
+    "IP address: shown in the printer's Wi-Fi settings.$\nDestination name: displayed on the printer's screen if it has one."
   Pop $0
-  ${NSD_CreateDropList} 0 26u 100% 10u ""
-  Pop $ComboDevice
-  ${If} $DeviceCount > 0
-    ; add every "display" from the parser ini (ip|name (ip))
-    StrCpy $R9 0
-    ${Do}
-      ${If} $R9 >= $DeviceCount
-        ${Break}
-      ${EndIf}
-      ReadIniStr $R8 "$DiscDir\devices.ini" "d" "$R9"
-      ${StrLoc} "$R5" "$R8" "|" "0"
-      ${If} "$R5" != ""
-        IntOp $R7 "$R5" + 1
-        StrCpy $R6 "$R8" "" $R7          ; display part: "name (ip)"
-        StrCpy $R4 "$R6"
-        ${NSD_CB_AddString} $ComboDevice "$R4"
-        ${If} $R9 == 0
-          ${NSD_CB_SelectString} $ComboDevice "$R4"
-        ${EndIf}
-      ${EndIf}
-      IntOp $R9 $R9 + 1
-    ${Loop}
-  ${EndIf}
 
-  ; how to reach the printer
-  ${NSD_CreateRadioButton} 8u 40u 90% 10u \
-    "Use the selected printer by name (recommended)"
-  Pop $RadioByName
-  ${NSD_AddStyle} $RadioByName ${WS_GROUP}
-  ${NSD_SetState} $RadioByName ${BST_CHECKED}
-
-  ${NSD_CreateRadioButton} 8u 51u 55% 10u \
-    "Pin by IP address instead:"
-  Pop $RadioByIp
-  ${NSD_CreateText} 60% 51u 36% 12u ""
-  Pop $EditIp
-
-  ${NSD_CreateRadioButton} 8u 64u 55% 10u \
-    "Enter it manually (name or IP):"
-  Pop $RadioOther
-  ${NSD_OnClick} $RadioOther OnOtherClick
-  ${NSD_CreateText} 60% 64u 36% 12u ""
-  Pop $EditOther
-  !insertmacro _CtrlEnable $EditOther 0
-
-  ${NSD_CreateRadioButton} 8u 77u 90% 10u \
-    "Configure later (you will edit config\\default.json yourself)"
+  ${NSD_CreateRadioButton} 8u 22u 90% 10u \
+    "Enter the printer IP address:"
   Pop $RadioLater
   ${NSD_AddStyle} $RadioLater ${WS_GROUP}
+  ${NSD_SetState} $RadioLater ${BST_CHECKED}
 
-  ; diagnostics: selectable log path + an "open folder" button
-  ${NSD_CreateLabel} 0 89u 100% 8u "Diagnostics (kept only on failure):"
-  Pop $0
-  ${NSD_CreateText} 0 97u 76% 12u ""
-  Pop $EditLogPath
-  ${NSD_AddStyle} $EditLogPath "${ES_READONLY}"
-  ${NSD_SetText} $EditLogPath "$LogPath"
-  ${NSD_CreateButton} 78% 97u 20% 12u "Open folder"
-  Pop $0
-  ${NSD_OnClick} $0 BrowseLogs
+  ${NSD_CreateText} 8u 34u 88% 12u ""
+  Pop $EditIp
 
-  ; compact everything vertically so it fits the wizard pane (~115u tall)
-  ${If} $DeviceCount == 0
-    ; no printers: the dropdown is useless, disable it and "by name"
-    System::Call "user32::EnableWindow(p$ComboDevice, i0)"
-    System::Call "user32::EnableWindow(p$RadioByName, i0)"
-    ${NSD_SetState} $RadioLater ${BST_CHECKED}
-  ${EndIf}
+  ${NSD_CreateLabel} 8u 52u 100% 8u "Destination name:"
+  Pop $0
+  ${NSD_CreateText} 8u 62u 88% 12u ""
+  Pop $EditLabel
+  ; prefill with the computer hostname (the app default)
+  StrCpy $R0 ${NSIS_MAX_STRLEN}
+  System::Call "kernel32::GetComputerNameW(w .r1, *i r0r0) i.r2"
+  ${NSD_SetText} $EditLabel "$R1"
+
+  ${NSD_CreateRadioButton} 8u 80u 90% 10u \
+    "Configure later (edit config\\default.json yourself)"
+  Pop $RadioLater2
+  ${NSD_AddStyle} $RadioLater2 ${WS_GROUP}
 
   nsDialogs::Show
 FunctionEnd
 
-Function BrowseLogs
-  ${If} ${FileExists} "$LogPath"
-    ExecShell "open" "explorer.exe" "/select,$LogPath"
-  ${Else}
-    MessageBox MB_OK|MB_ICONINFORMATION "No diagnostic log was written (discovery succeeded)."
-  ${EndIf}
-FunctionEnd
-
 Function DevicePageLeave
-  ${NSD_GetState} $RadioLater $0
+  ${NSD_GetState} $RadioLater2 $0
   ${If} $0 == ${BST_CHECKED}
     StrCpy $DeviceChoice "skip"
     Return
   ${EndIf}
 
-  ; "Pin by IP" - standalone, no device selection required
-  ${NSD_GetState} $RadioByIp $0
-  ${If} $0 == ${BST_CHECKED}
-    ${NSD_GetText} $EditIp $DevIp
-    ${If} "$DevIp" == ""
-      MessageBox MB_OK|MB_ICONEXCLAMATION \
-        "Please enter the printer's IP address (IPv4 or IPv6)."
-      Abort
-    ${EndIf}
-    ; verify the address answers
-    Push "$DevIp"
-    Call _FwDiscoveryAllow
-    nsExec::ExecToStack '"$DiscDir\node-hp-scan-to.exe" discover --timeout 4 --ip "$DevIp"'
-    Call _FwDiscoveryRemove
-    Pop $0
-    Pop $R1                       ; discard captured stdout
-    ${If} $0 != 0
-      MessageBox MB_OK|MB_ICONEXCLAMATION \
-        "No scan-capable device answered at $\"$DevIp$\".$\nCheck that the printer is powered on and connected to this network."
-      Abort
-    ${EndIf}
-    StrCpy $DeviceChoice "ip"
-    StrCpy $DevName ""            ; no mDNS name
-    Return
+  ${NSD_GetText} $EditIp $DevIp
+  ${If} "$DevIp" == ""
+    MessageBox MB_OK|MB_ICONEXCLAMATION \
+      "Please enter the printer's IP address (for example 192.168.1.53)."
+    Abort
   ${EndIf}
-
-  ; "Enter manually"
-  ${NSD_GetState} $RadioOther $0
-  ${If} $0 == ${BST_CHECKED}
-    ${NSD_GetText} $EditOther $DevName
-    ${If} "$DevName" == ""
-      MessageBox MB_OK|MB_ICONEXCLAMATION \
-        "Please enter a device name or an IP address."
-      Abort
-    ${EndIf}
-
-    ${StrRep} "$1" "$DevName" "." ""
-    ${StrRep} "$1" "$1" "0" ""
-    ${StrRep} "$1" "$1" "1" ""
-    ${StrRep} "$1" "$1" "2" ""
-    ${StrRep} "$1" "$1" "3" ""
-    ${StrRep} "$1" "$1" "4" ""
-    ${StrRep} "$1" "$1" "5" ""
-    ${StrRep} "$1" "$1" "6" ""
-    ${StrRep} "$1" "$1" "7" ""
-    ${StrRep} "$1" "$1" "8" ""
-    ${StrRep} "$1" "$1" "9" ""
-    ${If} "$1" == ""
-      StrCpy $DeviceChoice "ip"
-      StrCpy $DevIp "$DevName"
-      Call _FwDiscoveryAllow
-      nsExec::ExecToStack '"$DiscDir\node-hp-scan-to.exe" discover --timeout 4 --ip "$DevIp"'
-      Call _FwDiscoveryRemove
-    ${Else}
-      StrCpy $DeviceChoice "name"
-      Call _FwDiscoveryAllow
-      nsExec::ExecToStack '"$DiscDir\node-hp-scan-to.exe" discover --timeout 4 --name "$DevName"'
-      Call _FwDiscoveryRemove
-    ${EndIf}
-    Pop $0
-    Pop $R1                       ; discard captured stdout
-    ${If} $0 != 0
-      MessageBox MB_OK|MB_ICONEXCLAMATION \
-        "No scan-capable device answered at $\"$DevName$\".$\nCheck that the printer is powered on and connected to this network."
-      Abort
-    ${EndIf}
-    Return
+  ${NSD_GetText} $EditLabel $DevLabel
+  ${If} "$DevLabel" == ""
+    StrCpy $R0 ${NSIS_MAX_STRLEN}
+    System::Call "kernel32::GetComputerNameW(w .r1, *i r0r0) i.r2"
+    StrCpy $DevLabel "$R1"
   ${EndIf}
-
-  ; default path: the printer picked in the dropdown, by name
-  ${If} $DeviceCount > 0
-    ${NSD_GetText} $ComboDevice $R4     ; display "name (ip)"
-    ; strip the trailing " (ip)"
-    ${StrLoc} "$R5" "$R4" " (" "0"
-    ${If} "$R5" != ""
-      IntOp $R7 "$R5" - 1
-      StrCpy $DevName "$R4" $R7
-    ${Else}
-      StrCpy $DevName "$R4"
-    ${EndIf}
-    StrCpy $DeviceChoice "name"
-    Return
-  ${EndIf}
-
-  MessageBox MB_OK|MB_ICONEXCLAMATION \
-    "Please pick Pin by IP, Other, or Configure later - no printer was detected."
-  Abort
+  StrCpy $DeviceChoice "ip"
 FunctionEnd
 
 ; ---------------------------------------------------------------------------
 ; install
 
 Section "Install"
-  ; belt & braces: drop any discovery firewall rule left by a Back navigation
-  Call _FwDiscoveryRemove
-
   ${If} $Mode == "system"
     SetShellVarContext all
   ${Else}
@@ -621,10 +337,11 @@ Section "Install"
   FileOpen $0 "$ConfigDir\default.json" w
   FileWrite $0 "{$\r$\n"
   FileWrite $0 '  "directory": "$R0",$\r$\n'
-  ${If} $DeviceChoice == "name"
-    FileWrite $0 '  "name": "$DevName",$\r$\n'
-  ${ElseIf} $DeviceChoice == "ip"
+  ${If} $DeviceChoice == "ip"
     FileWrite $0 '  "ip": "$DevIp",$\r$\n'
+  ${EndIf}
+  ${If} "$DevLabel" != ""
+    FileWrite $0 '  "label": "$DevLabel",$\r$\n'
   ${EndIf}
   FileWrite $0 '  "debug": false$\r$\n'
   FileWrite $0 "}$\r$\n"

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -324,6 +324,25 @@ Section "Install"
     SetShellVarContext current
   ${EndIf}
 
+  ; stop any running instance before overwriting the binary: the scheduled
+  ; task / service holds a lock on node-hp-scan-to.exe and would otherwise
+  ; make the File instruction fail with "Error opening file for writing"
+  ${If} $Mode == "system"
+    ; stop the existing WinSW service (if present) so the binary is released;
+    ; the service is re-created below on `install`
+    nsExec::ExecToLog '"$INSTDIR\${APPNAME}-service.exe" stop'
+    Pop $0
+  ${Else}
+    nsExec::ExecToLog 'schtasks /End /TN "${APPNAME}"'
+    Pop $0
+  ${EndIf}
+  ${If} ${FileExists} "$INSTDIR\${APPNAME}.exe"
+    nsExec::ExecToLog 'taskkill /F /IM "${APPNAME}.exe"'
+    Pop $0
+  ${EndIf}
+  ; give the OS a moment to release the handle
+  Sleep 1500
+
   SetOutPath "$INSTDIR"
   File "/oname=${APPNAME}.exe" "staging\node-hp-scan-to.exe"
 

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -16,7 +16,7 @@ SetCompressor /SOLID lzma
 ; no branding beyond the project name: "HP ..." would look like an
 ; HP Inc. product - nominative/descriptive use only stays safe
 !define DISPLAY "${APPNAME}"
-!define PUBLISHER "Emmanuel Counasse"
+!define PUBLISHER "manuc66"
 
 !ifndef VERSION
   !define VERSION "0.0.0-dev"
@@ -56,11 +56,10 @@ Var DevName
 Var DevIp
 Var DeviceRaw         ; raw stdout of the discover run
 Var DeviceCount       ; number of parsed devices
-Var DeviceShown       ; number of rendered device radios
-Var RadioTmp          ; scratch handle holder for NSD_GetState
-Var YPos              ; dynamic vertical layout cursor
-Var Status            ; outcome of the discovery, shown at the top of the page
 Var DiscDir           ; LOCALAPPDATA dir hosting the discovery binary
+Var ComboDevice       ; dropdown with discovered printers (when > 0)
+Var EditLogPath       ; read-only text showing the diagnostic log path
+Var Status            ; outcome of the discovery, shown at the top of the page
 Var RadioByName
 Var RadioByIp
 Var RadioOther
@@ -382,137 +381,131 @@ Function DevicePageCreate
     "Select your printer" \
     "The printer can be located by name (recommended) or by fixed IP address."
 
-  ; discovery happens up-front; the wizard progress bar covers the wait
+  ; inform the user before the (blocking) discovery - no empty wizard page
+  Banner::show "Searching your network for printers...$\nThis can take up to 15 seconds."
+
   Call _RunDiscovery
   Pop $R0                       ; exit code
-  Pop $DeviceRaw                ; stdout
+  Pop $DeviceRaw                ; stdout (line echoes from the binary)
 
-  ; on failure, persist what we have to a temp log the user can attach
-  Push "$DeviceRaw"
-  Call _SlurpFile
-  Pop $R1
-  ${If} $R0 != 0
-    FileOpen $1 "$TEMP\node-hp-scan-to-discovery.log" w
-    FileWrite $1 "exit code: $R0$\r$\n$\r$\n--- stdout ---$\r$\n"
-    FileWrite $1 "$R1$\r$\n"
-    FileWrite $1 "--- end ---$\r$\n"
-    FileClose $1
-  ${EndIf}
+  Banner::destroy
 
+  ; on failure or empty result, persist diagnostics the user can open/copy
+  StrCpy $EditLogPath "$TEMP\node-hp-scan-to-discovery.log"
   ${If} $R0 == 0
     Call _ParseDevices
   ${Else}
     StrCpy $DeviceCount 0
+    FileOpen $0 "$EditLogPath" w
+    FileWrite $0 "exit code: $R0$\r$\n"
+    FileWrite $0 "--- stdout ---$\r$\n"
+    FileWrite $0 "$DeviceRaw$\r$\n"
+    FileWrite $0 "--- end ---$\r$\n"
+    FileClose $0
   ${EndIf}
 
   nsDialogs::Create 1018
   Pop $0
 
-  ${NSD_CreateLabel} 0 0 100% 18u \
-    "Detected printers are listed below. Locating the printer by name keeps working even when its IP address changes."
+  ${NSD_CreateLabel} 0 0 100% 16u \
+    "Select how node-hp-scan-to finds your printer, then continue."
   Pop $0
 
-  ; status line - shows the outcome of the discovery and, on failure,
-  ; the path to the diagnostic log written for support
-  ${NSD_CreateLabel} 8u 22u 96% 36u \
-    "Detection finished - select your printer below or pick another option."
+  ; result / status line
+  ${NSD_CreateLabel} 8u 18u 96% 20u "placeholder"
   Pop $Status
   ${If} $R0 == 0
     ${If} $DeviceCount == 0
-      ${NSD_SetText} $Status \
-        "No scan-capable printer was detected. Configure it manually below."
+      ${NSD_SetText} $Status "No scan-capable printer was detected."
+    ${ElseIf} $DeviceCount == 1
+      ${NSD_SetText} $Status "One printer was detected. Choose how to reach it below."
     ${Else}
-      ${NSD_SetText} $Status \
-        "Detection finished - select your printer among those found below."
+      ${NSD_SetText} $Status "$DeviceCount printers were detected. Pick one in the list below."
     ${EndIf}
   ${Else}
     ${NSD_SetText} $Status \
-      "Printer detection failed (code $R0). You can configure the printer manually below or pick Configure later.$\n$\nDiagnostic log: $TEMP\node-hp-scan-to-discovery.log"
+      "Printer detection failed (code $R0). You can still configure a printer manually below."
   ${EndIf}
 
-  ; one radio button per discovered device (first four)
-  StrCpy $DeviceShown 0
-  StrCpy $R9 0
-  ${Do}
-    ${If} $R9 >= $DeviceCount
-      ${Break}
-    ${EndIf}
-    ${If} $R9 >= 4
-      ${Break}
-    ${EndIf}
-    ReadIniStr $R8 "$DiscDir\devices.ini" "d" "$R9"
-    ${StrLoc} "$R5" "$R8" "|" "0"
-    ${If} "$R5" != ""
-      IntOp $R7 "$R5" + 1
-      StrCpy $R6 "$R8" "" $R7          ; display part
-      IntOp $0 "$R9" * 11
-      IntOp $0 "$0" + 68               ; vertical position in dialog units
-      StrCpy $1 "$0"
-      StrCpy $1 "$1u"
-      ${NSD_CreateRadioButton} 8u "$1" 90% 10u "$R6"
-      Pop $RadioTmp
-      WriteIniStr "$DiscDir\devices.ini" "h" "$R9" "$RadioTmp"
-      ${If} $R9 == 0
-        ${NSD_AddStyle} $RadioTmp ${WS_GROUP}
-        ${NSD_SetState} $RadioTmp ${BST_CHECKED}
+  ; printer dropdown (only when at least one device was found)
+  ${NSD_CreateLabel} 0 42u 100% 10u "Printer:"
+  Pop $0
+  ${NSD_CreateDropList} 0 52u 100% 90u ""
+  Pop $ComboDevice
+  ${If} $DeviceCount > 0
+    ; add every "display" from the parser ini (ip|name (ip))
+    StrCpy $R9 0
+    ${Do}
+      ${If} $R9 >= $DeviceCount
+        ${Break}
       ${EndIf}
-      IntOp $DeviceShown "$DeviceShown" + 1
-    ${EndIf}
-    IntOp $R9 "$R9" + 1
-  ${Loop}
+      ReadIniStr $R8 "$DiscDir\devices.ini" "d" "$R9"
+      ${StrLoc} "$R5" "$R8" "|" "0"
+      ${If} "$R5" != ""
+        IntOp $R7 "$R5" + 1
+        StrCpy $R6 "$R8" "" $R7          ; display part: "name (ip)"
+        StrCpy $R4 "$R6"
+        ${NSD_CB_AddString} $ComboDevice "$R4"
+        ${If} $R9 == 0
+          ${NSD_CB_SelectString} $ComboDevice "$R4"
+        ${EndIf}
+      ${EndIf}
+      IntOp $R9 $R9 + 1
+    ${Loop}
+  ${EndIf}
 
-  ; fixed controls below the device list: positions are computed from the
-  ; actual number of devices so the gap stays small
-  IntOp $YPos "$DeviceShown" * 11
-  IntOp $YPos "$YPos" + 68
-
-  StrCpy $1 "$YPos"
-  StrCpy $1 "$1u"
-  ${NSD_CreateRadioButton} 8u "$1" 90% 10u \
+  ; how to reach the printer
+  ${NSD_CreateRadioButton} 8u 64u 90% 10u \
     "Use the selected printer by name (recommended)"
   Pop $RadioByName
-  ; WS_GROUP opens a second radio group: name/ip is an attribute of the
-  ; device picked above, it must not unselect it (and vice versa)
   ${NSD_AddStyle} $RadioByName ${WS_GROUP}
   ${NSD_SetState} $RadioByName ${BST_CHECKED}
 
-  IntOp $YPos "$YPos" + 11
-  StrCpy $1 "$YPos"
-  StrCpy $1 "$1u"
-  ${NSD_CreateRadioButton} 8u "$1" 60% 10u \
-    "Pin by fixed IP address (manual):"
+  ${NSD_CreateRadioButton} 8u 76u 60% 10u \
+    "Pin by IP address instead"
   Pop $RadioByIp
-  ${NSD_CreateText} 68% "$1" 28% 12u ""
+  ${NSD_CreateText} 68% 76u 28% 12u ""
   Pop $EditIp
 
-  IntOp $YPos "$YPos" + 12
-  StrCpy $1 "$YPos"
-  StrCpy $1 "$1u"
-  ${NSD_CreateRadioButton} 8u "$1" 90% 10u \
-    "Other - enter it manually:"
+  ${NSD_CreateRadioButton} 8u 90u 90% 10u \
+    "Enter it manually (name or IP):"
   Pop $RadioOther
   ${NSD_OnClick} $RadioOther OnOtherClick
-
-  IntOp $YPos "$YPos" + 11
-  StrCpy $1 "$YPos"
-  StrCpy $1 "$1u"
-  ${NSD_CreateText} 24u "$1" 74% 12u ""
+  ${NSD_CreateText} 0 100u 100% 12u ""
   Pop $EditOther
   !insertmacro _CtrlEnable $EditOther 0
 
-  IntOp $YPos "$YPos" + 16
-  StrCpy $1 "$YPos"
-  StrCpy $1 "$1u"
-  ${NSD_CreateRadioButton} 8u "$1" 90% 10u \
-    "Configure later (you will have to edit config\\default.json yourself)"
+  ${NSD_CreateRadioButton} 8u 112u 90% 10u \
+    "Configure later (you will edit config\\default.json yourself)"
   Pop $RadioLater
   ${NSD_AddStyle} $RadioLater ${WS_GROUP}
 
-  ${If} $DeviceShown == 0
+  ; diagnostics: selectable log path + an "open folder" button
+  ${NSD_CreateLabel} 0 126u 100% 8u "Diagnostics (kept only on failure):"
+  Pop $0
+  ${NSD_CreateText} 0 134u 78% 12u ""
+  Pop $EditLogPath
+  ${NSD_SetText} $EditLogPath "$TEMP\node-hp-scan-to-discovery.log"
+  ${NSD_CreateButton} 80% 134u 18% 12u "Open folder"
+  Pop $0
+  ${NSD_OnClick} $0 BrowseLogs
+
+  ${If} $DeviceCount == 0
+    ; no printers: the dropdown is useless, disable it and "by name"
+    System::Call "user32::EnableWindow(p$ComboDevice, i0)"
+    System::Call "user32::EnableWindow(p$RadioByName, i0)"
     ${NSD_SetState} $RadioLater ${BST_CHECKED}
   ${EndIf}
 
   nsDialogs::Show
+FunctionEnd
+
+Function BrowseLogs
+  ${If} ${FileExists} "$EditLogPath"
+    ExecShell "open" "explorer.exe" "/select,$EditLogPath"
+  ${Else}
+    MessageBox MB_OK|MB_ICONINFORMATION "No diagnostic log was written (discovery succeeded)."
+  ${EndIf}
 FunctionEnd
 
 Function DevicePageLeave
@@ -522,7 +515,7 @@ Function DevicePageLeave
     Return
   ${EndIf}
 
-  ; "Pin by fixed IP" - standalone, no device selection required
+  ; "Pin by IP" - standalone, no device selection required
   ${NSD_GetState} $RadioByIp $0
   ${If} $0 == ${BST_CHECKED}
     ${NSD_GetText} $EditIp $DevIp
@@ -531,6 +524,8 @@ Function DevicePageLeave
         "Please enter the printer's IP address (IPv4 or IPv6)."
       Abort
     ${EndIf}
+    ; verify the address answers
+    Push "$DevIp"
     Call _FwDiscoveryAllow
     nsExec::ExecToStack '"$DiscDir\node-hp-scan-to.exe" discover --timeout 4 --ip "$DevIp"'
     Call _FwDiscoveryRemove
@@ -538,7 +533,7 @@ Function DevicePageLeave
     Pop $R1                       ; discard captured stdout
     ${If} $0 != 0
       MessageBox MB_OK|MB_ICONEXCLAMATION \
-        "No HP scan-capable device answered at $\"$DevIp$\".$\nCheck that the printer is powered on and connected to this network."
+        "No scan-capable device answered at $\"$DevIp$\".$\nCheck that the printer is powered on and connected to this network."
       Abort
     ${EndIf}
     StrCpy $DeviceChoice "ip"
@@ -546,6 +541,7 @@ Function DevicePageLeave
     Return
   ${EndIf}
 
+  ; "Enter manually"
   ${NSD_GetState} $RadioOther $0
   ${If} $0 == ${BST_CHECKED}
     ${NSD_GetText} $EditOther $DevName
@@ -570,7 +566,7 @@ Function DevicePageLeave
       StrCpy $DeviceChoice "ip"
       StrCpy $DevIp "$DevName"
       Call _FwDiscoveryAllow
-nsExec::ExecToStack '"$DiscDir\node-hp-scan-to.exe" discover --timeout 4 --ip "$DevIp"'
+      nsExec::ExecToStack '"$DiscDir\node-hp-scan-to.exe" discover --timeout 4 --ip "$DevIp"'
       Call _FwDiscoveryRemove
     ${Else}
       StrCpy $DeviceChoice "name"
@@ -582,41 +578,29 @@ nsExec::ExecToStack '"$DiscDir\node-hp-scan-to.exe" discover --timeout 4 --ip "$
     Pop $R1                       ; discard captured stdout
     ${If} $0 != 0
       MessageBox MB_OK|MB_ICONEXCLAMATION \
-        "No HP scan-capable device answered at $\"$DevName$\".$\nCheck that the printer is powered on and connected to this network."
+        "No scan-capable device answered at $\"$DevName$\".$\nCheck that the printer is powered on and connected to this network."
       Abort
     ${EndIf}
     Return
   ${EndIf}
 
-  ; a discovered device radio is checked -> use its name (only "by name"
-  ; remains in this group: pinning by IP is the dedicated radio above)
-  StrCpy $R9 0
-  ${Do}
-    ${If} $R9 >= $DeviceShown
-      ${Break}
+  ; default path: the printer picked in the dropdown, by name
+  ${If} $DeviceCount > 0
+    ${NSD_GetText} $ComboDevice $R4     ; display "name (ip)"
+    ; strip the trailing " (ip)"
+    ${StrLoc} "$R5" "$R4" " (" "0"
+    ${If} "$R5" != ""
+      IntOp $R7 "$R5" - 1
+      StrCpy $DevName "$R4" $R7
+    ${Else}
+      StrCpy $DevName "$R4"
     ${EndIf}
-    ReadIniStr $RadioTmp "$DiscDir\devices.ini" "h" "$R9"
-    ${NSD_GetState} $RadioTmp $0
-    ${If} $0 == ${BST_CHECKED}
-      ReadIniStr $R8 "$DiscDir\devices.ini" "d" "$R9"   ; ip|display
-      ${StrLoc} "$R5" "$R8" "|" "0"
-      ${If} "$R5" == ""
-        MessageBox MB_OK|MB_ICONEXCLAMATION "Internal error: malformed device entry."
-        Abort
-      ${EndIf}
-      StrCpy $R6 "$R8" $R5                                 ; ip
-      IntOp $R7 "$R5" + 1
-      StrCpy $R4 "$R8" "" $R7                              ; display
-      StrCpy $DeviceChoice "name"
-      StrCpy $DevIp "$R6"
-      ${StrRep} "$DevName" "$R4" " ($R6)" ""               ; strip " (ip)"
-      Return
-    ${EndIf}
-    IntOp $R9 "$R9" + 1
-  ${Loop}
+    StrCpy $DeviceChoice "name"
+    Return
+  ${EndIf}
 
   MessageBox MB_OK|MB_ICONEXCLAMATION \
-    "Please select a detected printer, pick Pin by IP, Other, or Configure later."
+    "Please pick Pin by IP, Other, or Configure later - no printer was detected."
   Abort
 FunctionEnd
 

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -13,7 +13,9 @@ RequestExecutionLevel highest
 SetCompressor /SOLID lzma
 
 !define APPNAME "node-hp-scan-to"
-!define DISPLAY "HP Scan to Computer"
+; no branding beyond the project name: "HP ..." would look like an
+; HP Inc. product - nominative/descriptive use only stays safe
+!define DISPLAY "${APPNAME}"
 !define PUBLISHER "Emmanuel Counasse"
 
 !ifndef VERSION
@@ -36,6 +38,7 @@ InstallDir "$LOCALAPPDATA\Programs\${APPNAME}"
 ${StrRep}
 ${StrLoc}
 
+
 !ifndef WS_GROUP
   !define WS_GROUP 0x00020000
 !endif
@@ -56,11 +59,14 @@ Var DeviceCount       ; number of parsed devices
 Var DeviceShown       ; number of rendered device radios
 Var RadioTmp          ; scratch handle holder for NSD_GetState
 Var YPos              ; dynamic vertical layout cursor
+Var Status            ; outcome of the discovery, shown at the top of the page
+Var DiscDir           ; LOCALAPPDATA dir hosting the discovery binary
 Var RadioByName
 Var RadioByIp
 Var RadioOther
 Var RadioLater
 Var EditOther
+Var EditIp
 
 ; startup behaviour
 Var RunArgs           ; arguments passed to node-hp-scan-to at boot
@@ -69,7 +75,17 @@ Var RadioAdf
 
 !define MUI_ABORTWARNING
 
+; non-endorsement / trademark / license notice, shown on the welcome page
+!define MUI_WELCOMEPAGE_TEXT \
+  "This wizard installs node-hp-scan-to, a free (MIT) community tool$\n\
+   that scans documents from your network printer to this computer.$\n$\n\
+   This is an independent project: it is NOT built by, endorsed by or$\n\
+   affiliated with HP Inc. $\"HP$\" and related marks are trademarks of their$\n\
+   respective owners, referenced here descriptively only.$\n$\n\
+   By continuing you accept the MIT license terms shown next."
+
 !insertmacro MUI_PAGE_WELCOME
+!insertmacro MUI_PAGE_LICENSE "..\..\LICENSE"
 Page custom ModePageCreate ModePageLeave
 Page custom DevicePageCreate DevicePageLeave
 Page custom StartupPageCreate StartupPageLeave
@@ -238,17 +254,35 @@ FunctionEnd
   System::Call "user32::EnableWindow(p${CTRL}, i${ENABLE})"
 !macroend
 
+; The compiled binary listens for mDNS answers, which trips the Windows
+; Firewall "allow access" dialog over the installer UI while nsExec waits -
+; experienced as a freeze, and skipping it silently kills discovery.
+; While elevated, whitelist the scratch copy for a moment; best effort only
+; (a non-elevated user install simply keeps the native prompt).
+!define FW_TEMP_RULE "node-hp-scan-to-setup-discovery"
+
+Function _FwDiscoveryAllow
+  nsExec::Exec 'netsh advfirewall firewall delete rule name="${FW_TEMP_RULE}"'
+  Pop $0
+  nsExec::Exec 'netsh advfirewall firewall add rule name="${FW_TEMP_RULE}" dir=in action=allow program="$DiscDir\node-hp-scan-to.exe" enable=yes profile=private'
+  Pop $0
+FunctionEnd
+
+Function _FwDiscoveryRemove
+  nsExec::Exec 'netsh advfirewall firewall delete rule name="${FW_TEMP_RULE}"'
+  Pop $0
+FunctionEnd
+
 ; parse $DeviceRaw ("name\tip" lines, \r\n separated) into
-; $PLUGINSDIR\devices.ini ([d] <index> = <ip>|<display>) and set $DeviceCount
+; $DiscDir\devices.ini ([d] <index> = <ip>|<display>) and set $DeviceCount
 Function _ParseDevices
   StrCpy $DeviceCount 0
-  Delete "$PLUGINSDIR\devices.ini"
+  Delete "$DiscDir\devices.ini"
   StrCpy $R2 "$DeviceRaw"
   ${Do}
     ${If} "$R2" == ""
       ${Break}
     ${EndIf}
-
     ; cut the first line off (handle both \n and \r\n endings)
     ${StrLoc} "$R3" "$R2" "$\n" "0"
     ${If} "$R3" == ""
@@ -278,7 +312,7 @@ Function _ParseDevices
     ${EndIf}
 
     ${If} $R9 == 1
-      WriteIniStr "$PLUGINSDIR\devices.ini" "d" "$DeviceCount" "$R8|$R6 ($R8)"
+      WriteIniStr "$DiscDir\devices.ini" "d" "$DeviceCount" "$R8|$R6 ($R8)"
       IntOp $DeviceCount "$DeviceCount" + 1
     ${EndIf}
   ${Loop}
@@ -293,23 +327,65 @@ Function OnOtherClick
   ${EndIf}
 FunctionEnd
 
+; -------------------------------------------------------------------
+; device selection page (synchronous discovery)
+
+Function _RunDiscovery
+  ; Extract to LOCALAPPDATA, not PLUGINSDIR (%TEMP%): WDAC/Device Guard
+  ; policies on managed machines typically block execution from Temp but
+  ; allow the user profile, so discovery keeps working on such hosts.
+  StrCpy $DiscDir "$LOCALAPPDATA\node-hp-scan-to-setup"
+  CreateDirectory "$DiscDir"
+  ; use a private extraction dir to avoid clobbering a running instance
+  SetOutPath "$DiscDir"
+  File "/oname=node-hp-scan-to.exe" "staging\node-hp-scan-to.exe"
+  Call _FwDiscoveryAllow
+  nsExec::ExecToStack '"$DiscDir\node-hp-scan-to.exe" discover --timeout 5'
+  Call _FwDiscoveryRemove
+FunctionEnd
+
+; read a whole text file onto the stack (path in, contents out)
+Function _SlurpFile
+  Pop $R8
+  ClearErrors
+  FileOpen $R7 "$R8" r
+  ${If} ${Errors}
+    Push ""
+    Return
+  ${EndIf}
+  StrCpy $R9 ""
+  ${Do}
+    FileRead $R7 $R6
+    ${If} ${Errors}
+      ${Break}
+    ${EndIf}
+    StrCpy $R9 "$R9$R6"
+  ${Loop}
+  FileClose $R7
+  Push $R9
+FunctionEnd
+
 Function DevicePageCreate
   !insertmacro MUI_HEADER_TEXT \
     "Select your printer" \
     "The printer can be located by name (recommended) or by fixed IP address."
 
-  ; run discovery from a temporary copy of the binary
-  File "/oname=$PLUGINSDIR\node-hp-scan-to.exe" "staging\node-hp-scan-to.exe"
-  nsExec::ExecToStack '"$PLUGINSDIR\node-hp-scan-to.exe" discover --timeout 5'
+  ; discovery happens up-front; the wizard progress bar covers the wait
+  Call _RunDiscovery
   Pop $R0                       ; exit code
   Pop $DeviceRaw                ; stdout
 
-  nsDialogs::Create 1018
-  Pop $0
-
-  ${NSD_CreateLabel} 0 0 100% 20u \
-    "Detected devices are listed below. Locating the printer by name keeps working even when its IP address changes."
-  Pop $0
+  ; on failure, persist what we have to a temp log the user can attach
+  Push "$DeviceRaw"
+  Call _SlurpFile
+  Pop $R1
+  ${If} $R0 != 0
+    FileOpen $1 "$TEMP\node-hp-scan-to-discovery.log" w
+    FileWrite $1 "exit code: $R0$\r$\n$\r$\n--- stdout ---$\r$\n"
+    FileWrite $1 "$R1$\r$\n"
+    FileWrite $1 "--- end ---$\r$\n"
+    FileClose $1
+  ${EndIf}
 
   ${If} $R0 == 0
     Call _ParseDevices
@@ -317,29 +393,53 @@ Function DevicePageCreate
     StrCpy $DeviceCount 0
   ${EndIf}
 
-  ; one radio button per discovered device (first six), using only the
-  ; basic nsDialogs macros - distro builds lack the LB_/CB_ helpers
+  nsDialogs::Create 1018
+  Pop $0
+
+  ${NSD_CreateLabel} 0 0 100% 18u \
+    "Detected printers are listed below. Locating the printer by name keeps working even when its IP address changes."
+  Pop $0
+
+  ; status line - shows the outcome of the discovery and, on failure,
+  ; the path to the diagnostic log written for support
+  ${NSD_CreateLabel} 8u 22u 96% 36u \
+    "Detection finished - select your printer below or pick another option."
+  Pop $Status
+  ${If} $R0 == 0
+    ${If} $DeviceCount == 0
+      ${NSD_SetText} $Status \
+        "No scan-capable printer was detected. Configure it manually below."
+    ${Else}
+      ${NSD_SetText} $Status \
+        "Detection finished - select your printer among those found below."
+    ${EndIf}
+  ${Else}
+    ${NSD_SetText} $Status \
+      "Printer detection failed (code $R0). You can configure the printer manually below or pick Configure later.$\n$\nDiagnostic log: $TEMP\node-hp-scan-to-discovery.log"
+  ${EndIf}
+
+  ; one radio button per discovered device (first four)
   StrCpy $DeviceShown 0
   StrCpy $R9 0
   ${Do}
     ${If} $R9 >= $DeviceCount
       ${Break}
     ${EndIf}
-    ${If} $R9 >= 6
+    ${If} $R9 >= 4
       ${Break}
     ${EndIf}
-    ReadIniStr $R8 "$PLUGINSDIR\devices.ini" "d" "$R9"
+    ReadIniStr $R8 "$DiscDir\devices.ini" "d" "$R9"
     ${StrLoc} "$R5" "$R8" "|" "0"
     ${If} "$R5" != ""
       IntOp $R7 "$R5" + 1
       StrCpy $R6 "$R8" "" $R7          ; display part
-      IntOp $0 "$R9" * 10
-      IntOp $0 "$0" + 26               ; vertical position in dialog units
+      IntOp $0 "$R9" * 11
+      IntOp $0 "$0" + 68               ; vertical position in dialog units
       StrCpy $1 "$0"
       StrCpy $1 "$1u"
       ${NSD_CreateRadioButton} 8u "$1" 90% 10u "$R6"
       Pop $RadioTmp
-      WriteIniStr "$PLUGINSDIR\devices.ini" "h" "$R9" "$RadioTmp"
+      WriteIniStr "$DiscDir\devices.ini" "h" "$R9" "$RadioTmp"
       ${If} $R9 == 0
         ${NSD_AddStyle} $RadioTmp ${WS_GROUP}
         ${NSD_SetState} $RadioTmp ${BST_CHECKED}
@@ -349,24 +449,31 @@ Function DevicePageCreate
     IntOp $R9 "$R9" + 1
   ${Loop}
 
-  ; fixed controls below the dynamic list
-  IntOp $YPos "$DeviceShown" * 10
-  IntOp $YPos "$YPos" + 28
+  ; fixed controls below the device list: positions are computed from the
+  ; actual number of devices so the gap stays small
+  IntOp $YPos "$DeviceShown" * 11
+  IntOp $YPos "$YPos" + 68
 
   StrCpy $1 "$YPos"
   StrCpy $1 "$1u"
   ${NSD_CreateRadioButton} 8u "$1" 90% 10u \
     "Use the selected printer by name (recommended)"
   Pop $RadioByName
+  ; WS_GROUP opens a second radio group: name/ip is an attribute of the
+  ; device picked above, it must not unselect it (and vice versa)
+  ${NSD_AddStyle} $RadioByName ${WS_GROUP}
+  ${NSD_SetState} $RadioByName ${BST_CHECKED}
 
-  IntOp $YPos "$YPos" + 12
+  IntOp $YPos "$YPos" + 11
   StrCpy $1 "$YPos"
   StrCpy $1 "$1u"
-  ${NSD_CreateRadioButton} 8u "$1" 90% 10u \
-    "Pin this printer by IP address (only if name lookup fails on your network)"
+  ${NSD_CreateRadioButton} 8u "$1" 60% 10u \
+    "Pin by fixed IP address (manual):"
   Pop $RadioByIp
+  ${NSD_CreateText} 68% "$1" 28% 12u ""
+  Pop $EditIp
 
-  IntOp $YPos "$YPos" + 14
+  IntOp $YPos "$YPos" + 12
   StrCpy $1 "$YPos"
   StrCpy $1 "$1u"
   ${NSD_CreateRadioButton} 8u "$1" 90% 10u \
@@ -381,7 +488,7 @@ Function DevicePageCreate
   Pop $EditOther
   !insertmacro _CtrlEnable $EditOther 0
 
-  IntOp $YPos "$YPos" + 18
+  IntOp $YPos "$YPos" + 16
   StrCpy $1 "$YPos"
   StrCpy $1 "$1u"
   ${NSD_CreateRadioButton} 8u "$1" 90% 10u \
@@ -400,6 +507,30 @@ Function DevicePageLeave
   ${NSD_GetState} $RadioLater $0
   ${If} $0 == ${BST_CHECKED}
     StrCpy $DeviceChoice "skip"
+    Return
+  ${EndIf}
+
+  ; "Pin by fixed IP" - standalone, no device selection required
+  ${NSD_GetState} $RadioByIp $0
+  ${If} $0 == ${BST_CHECKED}
+    ${NSD_GetText} $EditIp $DevIp
+    ${If} "$DevIp" == ""
+      MessageBox MB_OK|MB_ICONEXCLAMATION \
+        "Please enter the printer's IP address (IPv4 or IPv6)."
+      Abort
+    ${EndIf}
+    Call _FwDiscoveryAllow
+    nsExec::ExecToStack '"$PLUGINSDIR\node-hp-scan-to.exe" discover --timeout 4 --ip "$DevIp"'
+    Call _FwDiscoveryRemove
+    Pop $0
+    Pop $R1                       ; discard captured stdout
+    ${If} $0 != 0
+      MessageBox MB_OK|MB_ICONEXCLAMATION \
+        "No HP scan-capable device answered at $\"$DevIp$\".$\nCheck that the printer is powered on and connected to this network."
+      Abort
+    ${EndIf}
+    StrCpy $DeviceChoice "ip"
+    StrCpy $DevName ""            ; no mDNS name
     Return
   ${EndIf}
 
@@ -426,10 +557,14 @@ Function DevicePageLeave
     ${If} "$1" == ""
       StrCpy $DeviceChoice "ip"
       StrCpy $DevIp "$DevName"
+      Call _FwDiscoveryAllow
       nsExec::ExecToStack '"$PLUGINSDIR\node-hp-scan-to.exe" discover --timeout 4 --ip "$DevIp"'
+      Call _FwDiscoveryRemove
     ${Else}
       StrCpy $DeviceChoice "name"
+      Call _FwDiscoveryAllow
       nsExec::ExecToStack '"$PLUGINSDIR\node-hp-scan-to.exe" discover --timeout 4 --name "$DevName"'
+      Call _FwDiscoveryRemove
     ${EndIf}
     Pop $0
     Pop $R1                       ; discard captured stdout
@@ -441,16 +576,17 @@ Function DevicePageLeave
     Return
   ${EndIf}
 
-  ; a discovered device radio is checked -> resolve it through the ini
+  ; a discovered device radio is checked -> use its name (only "by name"
+  ; remains in this group: pinning by IP is the dedicated radio above)
   StrCpy $R9 0
   ${Do}
     ${If} $R9 >= $DeviceShown
       ${Break}
     ${EndIf}
-    ReadIniStr $RadioTmp "$PLUGINSDIR\devices.ini" "h" "$R9"
+    ReadIniStr $RadioTmp "$DiscDir\devices.ini" "h" "$R9"
     ${NSD_GetState} $RadioTmp $0
     ${If} $0 == ${BST_CHECKED}
-      ReadIniStr $R8 "$PLUGINSDIR\devices.ini" "d" "$R9"   ; ip|display
+      ReadIniStr $R8 "$DiscDir\devices.ini" "d" "$R9"   ; ip|display
       ${StrLoc} "$R5" "$R8" "|" "0"
       ${If} "$R5" == ""
         MessageBox MB_OK|MB_ICONEXCLAMATION "Internal error: malformed device entry."
@@ -459,22 +595,16 @@ Function DevicePageLeave
       StrCpy $R6 "$R8" $R5                                 ; ip
       IntOp $R7 "$R5" + 1
       StrCpy $R4 "$R8" "" $R7                              ; display
+      StrCpy $DeviceChoice "name"
       StrCpy $DevIp "$R6"
-      ${NSD_GetState} $RadioByIp $0
-      ${If} $0 == ${BST_CHECKED}
-        StrCpy $DeviceChoice "ip"
-        StrCpy $DevName "$R4"
-      ${Else}
-        StrCpy $DeviceChoice "name"
-        ${StrRep} "$DevName" "$R4" " ($R6)" ""             ; strip " (ip)"
-      ${EndIf}
+      ${StrRep} "$DevName" "$R4" " ($R6)" ""               ; strip " (ip)"
       Return
     ${EndIf}
     IntOp $R9 "$R9" + 1
   ${Loop}
 
   MessageBox MB_OK|MB_ICONEXCLAMATION \
-    "Please select a detected printer, choose Other, or pick Configure later."
+    "Please select a detected printer, pick Pin by IP, Other, or Configure later."
   Abort
 FunctionEnd
 
@@ -482,6 +612,9 @@ FunctionEnd
 ; install
 
 Section "Install"
+  ; belt & braces: drop any discovery firewall rule left by a Back navigation
+  Call _FwDiscoveryRemove
+
   ${If} $Mode == "system"
     SetShellVarContext all
   ${Else}
@@ -555,6 +688,12 @@ Section "Install"
     FileWrite $0 '".\node-hp-scan-to.exe" $RunArgs >> "%LOG%" 2>&1$\r$\n'
     FileClose $0
 
+    ; hidden-console helper for the fallback task below: wscript hosts no
+    ; window of its own and Run(...,0) hides the batch console entirely
+    FileOpen $0 "$INSTDIR\run-hidden.vbs" w
+    FileWrite $0 'CreateObject("WScript.Shell").Run """$INSTDIR\run.cmd""", 0$\r$\n'
+    FileClose $0
+
     ; S4U task: session 0 (no window), restart-on-failure, no time limit.
     ; $$ keeps PowerShell variables away from NSIS expansion; quadrupled
     ; quotes survive argv+PS so Task Scheduler stores /c ""path"".
@@ -562,7 +701,7 @@ Section "Install"
     Pop $0
     ${If} $0 != 0
       DetailPrint "Scheduled task registration failed ($0) - falling back to simple ONLOGON task."
-      nsExec::ExecToLog 'schtasks /Create /F /TN "${APPNAME}" /SC ONLOGON /RL LIMITED /TR "\"$INSTDIR\run.cmd\""'
+      nsExec::ExecToLog 'schtasks /Create /F /TN "${APPNAME}" /SC ONLOGON /RL LIMITED /TR "\"$WINDIR\System32\wscript.exe\" \"$INSTDIR\run-hidden.vbs\""'
     ${EndIf}
 
     nsExec::ExecToLog 'schtasks /Run /TN "${APPNAME}"'
@@ -573,7 +712,7 @@ Section "Install"
     FileWrite $0 "<service>$\r$\n"
     FileWrite $0 "  <id>${APPNAME}</id>$\r$\n"
     FileWrite $0 "  <name>${DISPLAY}</name>$\r$\n"
-    FileWrite $0 "  <description>Scan document to Computer for HP All-in-One Printers</description>$\r$\n"
+    FileWrite $0 "  <description>Scan from the printer's panel to this computer - independent community tool, not affiliated with HP Inc.</description>$\r$\n"
     FileWrite $0 "  <executable>$INSTDIR\${APPNAME}.exe</executable>$\r$\n"
     FileWrite $0 "  <arguments>$RunArgs</arguments>$\r$\n"
     FileWrite $0 "  <workingdirectory>$INSTDIR</workingdirectory>$\r$\n"

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -75,6 +75,9 @@ Var RadioAdf
 
 !define MUI_ABORTWARNING
 
+; documentation opened from the Finish page (swap for a dedicated docs site when available)
+!define DOC_URL "https://manuc66.github.io/node-hp-scan-to/"
+
 ; non-endorsement / trademark / license notice, shown on the welcome page
 !define MUI_WELCOMEPAGE_TEXT \
   "This wizard installs node-hp-scan-to, a free (MIT) community tool$\n\
@@ -86,6 +89,15 @@ Var RadioAdf
 
 !insertmacro MUI_PAGE_WELCOME
 !insertmacro MUI_PAGE_LICENSE "..\..\LICENSE"
+
+; Finish page: link to the docs plus an optional "edit the config" shortcut
+; (notepad.exe is used as a plain text editor, safe everywhere)
+!define MUI_FINISHPAGE_LINK "Open the node-hp-scan-to documentation"
+!define MUI_FINISHPAGE_LINK_LOCATION "${DOC_URL}"
+!define MUI_FINISHPAGE_RUN "notepad.exe"
+!define MUI_FINISHPAGE_RUN_PARAMETERS "$\"$ConfigDir\default.json$\""
+!define MUI_FINISHPAGE_RUN_TEXT "Open the configuration file for editing"
+!define MUI_FINISHPAGE_RUN_CHECKED
 Page custom ModePageCreate ModePageLeave
 Page custom DevicePageCreate DevicePageLeave
 Page custom StartupPageCreate StartupPageLeave

--- a/scripts/build-binaries.sh
+++ b/scripts/build-binaries.sh
@@ -21,6 +21,22 @@ VERSION="${VERSION#v}"
 TARGETS=(${TARGETS:-bun-windows-x64 bun-darwin-x64 bun-darwin-arm64 bun-linux-x64 bun-linux-arm64 bun-linux-x64-musl bun-linux-arm64-musl})
 OUT_DIR="${OUT_DIR:-release}"
 
+# The --windows-* metadata flags only work when bun itself runs on a
+# Windows host; on any other host they make the build abort, so they are
+# only applied for a native bun-windows-x64 build.
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) HOST_IS_WINDOWS=1 ;;
+  *) HOST_IS_WINDOWS=0 ;;
+esac
+
+# bun's --windows-version expects a numeric 4-part version. Versions such
+# as "1.10.0-local" or "0.0.0-dispatch" would be silently truncated by bun,
+# so normalize to major.minor.patch.0 up front.
+WIN_VERSION="0.0.0.0"
+if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+  WIN_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}.0"
+fi
+
 command -v bun >/dev/null 2>&1 || { echo "error: bun is not installed" >&2; exit 1; }
 
 node getCommitId.js
@@ -46,12 +62,12 @@ for target in "${TARGETS[@]}"; do
 
   mkdir -p "$stage"
   WINDOWS_EXTRA=()
-  if [ "$os" = windows ]; then
+  if [ "$os" = windows ] && [ "$HOST_IS_WINDOWS" = 1 ]; then
     WINDOWS_EXTRA+=(
       --windows-icon="assets/icon.ico"
       --windows-title="node-hp-scan-to"
       --windows-publisher="manuc66"
-      --windows-version="$VERSION.0"
+      --windows-version="$WIN_VERSION"
       --windows-description="Scan document to Computer from your printer"
       --windows-copyright="Copyright 2026 manuc66"
     )

--- a/scripts/build-binaries.sh
+++ b/scripts/build-binaries.sh
@@ -45,9 +45,21 @@ for target in "${TARGETS[@]}"; do
   echo "==> building $target -> $stage/$name$ext"
 
   mkdir -p "$stage"
+  WINDOWS_EXTRA=()
+  if [ "$os" = windows ]; then
+    WINDOWS_EXTRA+=(
+      --windows-icon="assets/icon.ico"
+      --windows-title="node-hp-scan-to"
+      --windows-publisher="manuc66"
+      --windows-version="$VERSION.0"
+      --windows-description="Scan document to Computer from your printer"
+      --windows-copyright="Copyright 2026 manuc66"
+    )
+  fi
   bun build --compile \
     --target="$target" \
     --outfile "$stage/$name" \
+    "${WINDOWS_EXTRA[@]}" \
     src/index.ts
 
   mkdir -p "$stage/config"

--- a/scripts/build-installer.ps1
+++ b/scripts/build-installer.ps1
@@ -51,7 +51,14 @@ try {
     if (-not $SkipBinary) {
         Write-Host "==> compiling binary with bun ($bunExe)"
         New-Item -ItemType Directory -Force -Path packaging\windows\staging | Out-Null
+        $ver = $Version.TrimStart("v")
         & $bunExe build --compile --target=bun-windows-x64 `
+            --windows-icon (Join-Path $repoRoot "assets\icon.ico") `
+            --windows-title "node-hp-scan-to" `
+            --windows-publisher "manuc66" `
+            --windows-version "$ver.0" `
+            --windows-description "Scan document to Computer from your printer" `
+            --windows-copyright "Copyright 2026 manuc66" `
             --outfile packaging\windows\staging\node-hp-scan-to.exe src/index.ts
         if ($LASTEXITCODE -ne 0) { throw "bun build failed" }
     }

--- a/scripts/build-installer.ps1
+++ b/scripts/build-installer.ps1
@@ -1,0 +1,80 @@
+# Build the Windows installer locally, end to end:
+#   1. compile src/index.ts into a self-contained bun binary
+#   2. fetch WinSW if not already staged
+#   3. assemble the NSIS installer into release/
+#
+# Usage:
+#   ./scripts/build-installer.ps1 [-Version 1.10.0-local] [-SkipBinary] [-SkipNpmInstall]
+#
+# Prerequisites: bun + NSIS (winget install Oven-sh.Bun NSIS.NSIS), pnpm deps installed.
+[CmdletBinding()]
+param(
+    [string]$Version = "1.10.0-local",
+    [switch]$SkipBinary,
+    [switch]$SkipNpmInstall
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+# locate bun (winget install does not always refresh the current session PATH)
+$bun = Get-Command bun -ErrorAction SilentlyContinue
+if (-not $bun) {
+    $bunCandidate = Get-ChildItem "$env:LOCALAPPDATA\Microsoft\WinGet\Packages\Oven-sh.Bun_*" `
+        -Filter bun.exe -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($bunCandidate) { $bun = $bunCandidate }
+}
+if (-not $bun) { throw "bun not found - run: winget install Oven-sh.Bun" }
+$bunExe = if ($bun.Source) { $bun.Source } else { $bun.FullName }
+
+# locate makensis
+$nsis = "C:\Program Files (x86)\NSIS\makensis.exe"
+if (-not (Test-Path $nsis)) {
+    $nsis = (Get-Command makensis -ErrorAction SilentlyContinue).Source
+}
+if (-not (Test-Path $nsis)) { throw "makensis not found - run: winget install NSIS.NSIS" }
+
+Push-Location $repoRoot
+try {
+    # npm dependencies are required for bun to resolve imports
+    if (-not (Test-Path node_modules) -and -not $SkipNpmInstall) {
+        Write-Host "==> installing npm dependencies (pnpm)"
+        & pnpm install --frozen-lockfile
+        if ($LASTEXITCODE -ne 0) { throw "pnpm install failed" }
+    }
+
+    # commit id baked into --version output (mirrors build-binaries.sh)
+    Write-Host "==> baking commit id"
+    & node getCommitId.js
+    if ($LASTEXITCODE -ne 0) { throw "getCommitId.js failed" }
+
+    if (-not $SkipBinary) {
+        Write-Host "==> compiling binary with bun ($bunExe)"
+        New-Item -ItemType Directory -Force -Path packaging\windows\staging | Out-Null
+        & $bunExe build --compile --target=bun-windows-x64 `
+            --outfile packaging\windows\staging\node-hp-scan-to.exe src/index.ts
+        if ($LASTEXITCODE -ne 0) { throw "bun build failed" }
+    }
+
+    # WinSW only needed by system mode, fetched once
+    $winsw = "packaging\windows\staging\WinSW-x64.exe"
+    if (-not (Test-Path $winsw)) {
+        Write-Host "==> downloading WinSW-x64.exe"
+        Invoke-WebRequest `
+            -Uri "https://github.com/winsw/winsw/releases/download/v2.12.0/WinSW-x64.exe" `
+            -OutFile $winsw
+    }
+
+    $releaseDir = Join-Path $repoRoot "release"
+    New-Item -ItemType Directory -Force -Path $releaseDir | Out-Null
+
+    Write-Host "==> building installer (NSIS)"
+    & $nsis "-DVERSION=$Version" packaging\windows\installer.nsi
+    if ($LASTEXITCODE -ne 0) { throw "makensis failed" }
+
+    $out = Join-Path $releaseDir "setup-node-hp-scan-to-v$Version.exe"
+    Write-Host ""
+    Write-Host "OK: $out ($([math]::Round((Get-Item $out).Length / 1MB, 1)) MB)"
+} finally {
+    Pop-Location
+}

--- a/scripts/build-installer.ps1
+++ b/scripts/build-installer.ps1
@@ -52,11 +52,18 @@ try {
         Write-Host "==> compiling binary with bun ($bunExe)"
         New-Item -ItemType Directory -Force -Path packaging\windows\staging | Out-Null
         $ver = $Version.TrimStart("v")
+        # bun's --windows-version expects a numeric 4-part version; suffixes
+        # such as "-local" are silently dropped by bun, so normalize to
+        # major.minor.patch.0 up front.
+        $winVer = "0.0.0.0"
+        if ($ver -match '^(\d+)\.(\d+)\.(\d+)') {
+            $winVer = "$($matches[1]).$($matches[2]).$($matches[3]).0"
+        }
         & $bunExe build --compile --target=bun-windows-x64 `
             --windows-icon (Join-Path $repoRoot "assets\icon.ico") `
             --windows-title "node-hp-scan-to" `
             --windows-publisher "manuc66" `
-            --windows-version "$ver.0" `
+            --windows-version "$winVer" `
             --windows-description "Scan document to Computer from your printer" `
             --windows-copyright "Copyright 2026 manuc66" `
             --outfile packaging\windows\staging\node-hp-scan-to.exe src/index.ts

--- a/scripts/sign-local.ps1
+++ b/scripts/sign-local.ps1
@@ -1,0 +1,111 @@
+# Sign a locally built Windows installer with a self-signed Certificate
+# Authority cert so Windows Defender Application Control (WDAC) stops
+# blocking it on this machine.
+#
+# This is for DEVELOPMENT ONLY: the certificate is self-signed, valid here
+# only, and NOT suitable for distribution. Releases must be signed via
+# SignPath (see .github/workflows/publish.yml) or a real code-signing cert.
+#
+# Usage:
+#   ./scripts/sign-local.ps1 [-InstallerPath <path to setup exe>]
+#
+# Defaults to the latest setup-*.exe in release/.
+[CmdletBinding()]
+param(
+    [string]$CertSubject = "CN=node-hp-scan-to Local Test",
+    [string]$InstallerPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+# locate signtool (Windows SDK)
+$signtool = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin\*" `
+    -Filter signtool.exe -Recurse -ErrorAction SilentlyContinue |
+    Where-Object { $_.FullName -match "x64" } |
+    Sort-Object FullName -Descending | Select-Object -First 1
+if (-not $signtool) {
+    throw "signtool.exe not found - install the Windows SDK (winget install Microsoft.WindowsSDK.10.0)"
+}
+
+# find installer to sign
+if (-not $InstallerPath) {
+    $candidate = Get-ChildItem -Path (Join-Path $repoRoot "release") `
+        -Filter "setup-*.exe" -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime -Descending | Select-Object -First 1
+    if ($candidate) { $InstallerPath = $candidate.FullName }
+}
+if (-not $InstallerPath) {
+    throw "no installer found in release/ - build one first (scripts/build-installer.ps1)"
+}
+# ensure a full path regardless of how it was supplied
+$InstallerPath = (Resolve-Path -LiteralPath $InstallerPath).Path
+
+# reuse an existing cert if still valid, otherwise create a new one
+$existing = Get-ChildItem Cert:\CurrentUser\My | Where-Object {
+    $_.Subject -eq $CertSubject -and $_.NotAfter -gt (Get-Date).AddDays(1) -and $_.Issuer -ne $_.Subject
+} | Select-Object -First 1
+if (-not $existing) {
+    # build a proper CA (root) -> leaf (code-signing) chain: WDAC "Enterprise
+    # signing level" requires the leaf's issuer to be a trusted root, so a
+    # plain self-issued leaf is not enough on strict machines.
+    Write-Host "==> creating CA root + code-signing leaf certificate"
+
+    $rootSubject = "CN=node-hp-scan-to Local Test CA"
+
+    # root CA
+    $root = New-SelfSignedCertificate `
+        -Subject $rootSubject `
+        -Type Custom `
+        -KeyUsage CertSign, CRLSign, DigitalSignature `
+        -TextExtension @("2.5.29.19={critical}{text}ca=1&pathlength=0") `
+        -CertStoreLocation Cert:\CurrentUser\My `
+        -KeySpec KeyExchange `
+        -KeyExportPolicy Exportable `
+        -NotAfter (Get-Date).AddYears(3)
+
+    # leaf code-signing cert signed by the root
+    $existing = New-SelfSignedCertificate `
+        -Subject $CertSubject `
+        -Type CodeSigningCert `
+        -Signer $root `
+        -KeyUsage DigitalSignature `
+        -KeySpec Signature `
+        -CertStoreLocation Cert:\CurrentUser\My `
+        -NotAfter (Get-Date).AddDays(30)
+}
+
+# trust the signing chain at CurrentUser level so WDAC on this box stops
+# blocking the exe: leaf -> TrustedPublisher, its issuer -> Root
+$TrustRoot = Get-Item "Cert:\CurrentUser\My\$($existing.Issuer.Substring(3))" -ErrorAction SilentlyContinue
+if (-not $TrustRoot) {
+    # resolve issuer by subject (issuer string is CN=<name>)
+    $issuerCN = $existing.Issuer -replace '^CN=', ''
+    $TrustRoot = Get-ChildItem Cert:\CurrentUser\My | Where-Object { $_.Subject -eq "CN=$issuerCN" } | Select-Object -First 1
+}
+foreach ($pair in @(
+        @{ Store = "TrustedPublisher"; Cert = $existing },
+        @{ Store = "Root"; Cert = $TrustRoot }
+    )) {
+    if (-not $pair.Cert) { continue }
+    $store = New-Object System.Security.Cryptography.X509Certificates.X509Store($pair.Store, "CurrentUser")
+    $store.Open("ReadWrite")
+    try {
+        $already = $store.Certificates | Where-Object { $_.Thumbprint -eq $pair.Cert.Thumbprint }
+        if (-not $already) {
+            $store.Add($pair.Cert)
+            Write-Host "==> added $($pair.Cert.Subject) to $($pair.Store) (CurrentUser)"
+        } else {
+            Write-Host "==> $($pair.Store) already trusts $($pair.Cert.Subject)"
+        }
+    } finally {
+        $store.Close()
+    }
+}
+
+# sign with the leaf (code-signing) cert
+Write-Host "==> signing (leaf: $($existing.Subject))"
+& $signtool.FullName sign /fd SHA256 /sha1 $existing.Thumbprint `
+    /tr "http://timestamp.digicert.com" /td SHA256 $InstallerPath
+if ($LASTEXITCODE -ne 0) { throw "signtool failed" }
+Write-Host "OK: signed $InstallerPath"

--- a/src/commands/discoverCmd.ts
+++ b/src/commands/discoverCmd.ts
@@ -1,6 +1,4 @@
 import axios from "axios";
-import { execFile as execFileCb } from "node:child_process";
-import { promisify } from "node:util";
 // default-import + destructure: this dependency is CommonJS and some loaders
 // (tsx) do not expose its named exports to ESM consumers
 import bonjourService, {
@@ -8,7 +6,6 @@ import bonjourService, {
 } from "bonjour-service";
 
 const { Bonjour } = bonjourService;
-const execFile = promisify(execFileCb);
 
 export interface DiscoveredDevice {
   name: string;
@@ -47,109 +44,6 @@ async function probeDevice(ip: string): Promise<boolean> {
   } catch {
     return false;
   }
-}
-
-/**
- * Parse the local ARP cache ("arp -a") into { mac, ip } pairs. Non-invasive:
- * we only ever reach out to addresses already known to the OS, never sweep
- * the whole subnet.
- */
-async function getArpCache(): Promise<Array<{ ip: string; mac: string }>> {
-  try {
-    const { stdout } = await execFile("arp", ["-a"], { timeout: 3000 });
-    const entries: Array<{ ip: string; mac: string }> = [];
-    for (const line of stdout.split(/\r?\n/)) {
-      const m = line.match(
-        /\s(\d{1,3}(?:\.\d{1,3}){3})\s+([0-9a-f]{2}(?:-[0-9a-f]{2}){5})\s/i,
-      );
-      if (m) {
-        entries.push({
-          ip: m[1],
-          // normalise dashes -> colons, lowercase
-          mac: m[2].replace(/-/g, ":").toLowerCase(),
-        });
-      }
-    }
-    return entries;
-  } catch {
-    return [];
-  }
-}
-
-/**
- * Fallback discovery when mDNS finds nothing: inspect the local ARP cache
- * (already-known neighbours only - not a subnet sweep) and probe each host
- * for an HP DiscoveryTree or an eSCL endpoint.
- */
-async function scanKnownArpNeighbours(): Promise<DiscoveredDevice[]> {
-  const entries = await getArpCache();
-  // dedupe by ip; no MAC filtering so non-HP eSCL-only scanners are covered
-  const seen = new Set<string>();
-  const neighbours = entries.filter((e) => {
-    if (seen.has(e.ip)) {
-      return false;
-    }
-    seen.add(e.ip);
-    return true;
-  });
-  console.error(
-    `Probing ${neighbours.length} neighbour(s) from the local ARP cache (mDNS found nothing)...`,
-  );
-  const found: DiscoveredDevice[] = [];
-  await Promise.all(
-    neighbours.map(async ({ ip }) => {
-      const probe = await probeDeviceAndGetName(ip);
-      if (probe) {
-        found.push(probe);
-      }
-    }),
-  );
-  return found;
-}
-
-/** probe either HP DiscoveryTree.xml or an eSCL endpoint */
-async function probeDeviceAndGetName(
-  ip: string,
-): Promise<DiscoveredDevice | null> {
-  // 1) HP proprietary discovery tree
-  try {
-    const response = await axios.get<string>(
-      `http://${ip}/DevMgmt/DiscoveryTree.xml`,
-      { timeout: PROBE_TIMEOUT_MS, responseType: "text" },
-    );
-    if (response.status === 200 && looksLikeHpScanDevice(response.data)) {
-      const name =
-        response.data.match(
-          /<dd:FriendlyName>([^<]+)<\/dd:FriendlyName>/,
-        )?.[1]?.trim() ||
-        response.data.match(/<FriendlyName>([^<]+)<\/FriendlyName>/)?.[1]
-          ?.trim() ||
-        ip;
-      return { name, ip };
-    }
-  } catch {
-    // not an HP DiscoveryTree host
-  }
-
-  // 2) eSCL scanner capabilities (great for non-HP AirPrint/eSCL scanners)
-  try {
-    const response = await axios.get<string>(
-      `http://${ip}/eSCL/ScannerCapabilities.xml`,
-      { timeout: PROBE_TIMEOUT_MS, responseType: "text" },
-    );
-    if (response.status === 200 && /<Scan:ScannerCapabilities>/.test(response.data)) {
-      const name =
-        response.data.match(/<dc:modelName>([^<]+)<\/dc:modelName>/)?.[1]
-          ?.trim() ||
-        response.data.match(/<modelName>([^<]+)<\/modelName>/)?.[1]?.trim() ||
-        ip;
-      return { name, ip };
-    }
-  } catch {
-    // not an eSCL scanner
-  }
-
-  return null;
 }
 
 /**
@@ -250,20 +144,11 @@ export async function discoverCmd(options: DiscoverOptions): Promise<number> {
   const devices = candidates.filter((_, index) => checks[index]);
   devices.sort((a, b) => a.name.localeCompare(b.name));
 
-  // mDNS can miss printers that do not answer multicast (VLAN, AP filters);
-  // fall back to probing HP neighbours already known to the OS (ARP cache)
-  const finalDevices =
-    devices.length > 0 || options.name !== undefined
-      ? devices
-      : (await scanKnownArpNeighbours()).sort((a, b) =>
-          a.name.localeCompare(b.name),
-        );
-
-  if (finalDevices.length === 0) {
+  if (devices.length === 0) {
     console.error("No HP scan-capable device found");
     return 1;
   }
 
-  printDevices(finalDevices, options.json);
+  printDevices(devices, options.json);
   return 0;
 }

--- a/src/commands/discoverCmd.ts
+++ b/src/commands/discoverCmd.ts
@@ -1,9 +1,14 @@
 import axios from "axios";
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
 // default-import + destructure: this dependency is CommonJS and some loaders
 // (tsx) do not expose its named exports to ESM consumers
-import bonjourService from "bonjour-service";
+import bonjourService, {
+  type Browser as BonjourBrowser,
+} from "bonjour-service";
 
 const { Bonjour } = bonjourService;
+const execFile = promisify(execFileCb);
 
 export interface DiscoveredDevice {
   name: string;
@@ -45,6 +50,109 @@ async function probeDevice(ip: string): Promise<boolean> {
 }
 
 /**
+ * Parse the local ARP cache ("arp -a") into { mac, ip } pairs. Non-invasive:
+ * we only ever reach out to addresses already known to the OS, never sweep
+ * the whole subnet.
+ */
+async function getArpCache(): Promise<Array<{ ip: string; mac: string }>> {
+  try {
+    const { stdout } = await execFile("arp", ["-a"], { timeout: 3000 });
+    const entries: Array<{ ip: string; mac: string }> = [];
+    for (const line of stdout.split(/\r?\n/)) {
+      const m = line.match(
+        /\s(\d{1,3}(?:\.\d{1,3}){3})\s+([0-9a-f]{2}(?:-[0-9a-f]{2}){5})\s/i,
+      );
+      if (m) {
+        entries.push({
+          ip: m[1],
+          // normalise dashes -> colons, lowercase
+          mac: m[2].replace(/-/g, ":").toLowerCase(),
+        });
+      }
+    }
+    return entries;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Fallback discovery when mDNS finds nothing: inspect the local ARP cache
+ * (already-known neighbours only - not a subnet sweep) and probe each host
+ * for an HP DiscoveryTree or an eSCL endpoint.
+ */
+async function scanKnownArpNeighbours(): Promise<DiscoveredDevice[]> {
+  const entries = await getArpCache();
+  // dedupe by ip; no MAC filtering so non-HP eSCL-only scanners are covered
+  const seen = new Set<string>();
+  const neighbours = entries.filter((e) => {
+    if (seen.has(e.ip)) {
+      return false;
+    }
+    seen.add(e.ip);
+    return true;
+  });
+  console.error(
+    `Probing ${neighbours.length} neighbour(s) from the local ARP cache (mDNS found nothing)...`,
+  );
+  const found: DiscoveredDevice[] = [];
+  await Promise.all(
+    neighbours.map(async ({ ip }) => {
+      const probe = await probeDeviceAndGetName(ip);
+      if (probe) {
+        found.push(probe);
+      }
+    }),
+  );
+  return found;
+}
+
+/** probe either HP DiscoveryTree.xml or an eSCL endpoint */
+async function probeDeviceAndGetName(
+  ip: string,
+): Promise<DiscoveredDevice | null> {
+  // 1) HP proprietary discovery tree
+  try {
+    const response = await axios.get<string>(
+      `http://${ip}/DevMgmt/DiscoveryTree.xml`,
+      { timeout: PROBE_TIMEOUT_MS, responseType: "text" },
+    );
+    if (response.status === 200 && looksLikeHpScanDevice(response.data)) {
+      const name =
+        response.data.match(
+          /<dd:FriendlyName>([^<]+)<\/dd:FriendlyName>/,
+        )?.[1]?.trim() ||
+        response.data.match(/<FriendlyName>([^<]+)<\/FriendlyName>/)?.[1]
+          ?.trim() ||
+        ip;
+      return { name, ip };
+    }
+  } catch {
+    // not an HP DiscoveryTree host
+  }
+
+  // 2) eSCL scanner capabilities (great for non-HP AirPrint/eSCL scanners)
+  try {
+    const response = await axios.get<string>(
+      `http://${ip}/eSCL/ScannerCapabilities.xml`,
+      { timeout: PROBE_TIMEOUT_MS, responseType: "text" },
+    );
+    if (response.status === 200 && /<Scan:ScannerCapabilities>/.test(response.data)) {
+      const name =
+        response.data.match(/<dc:modelName>([^<]+)<\/dc:modelName>/)?.[1]
+          ?.trim() ||
+        response.data.match(/<modelName>([^<]+)<\/modelName>/)?.[1]?.trim() ||
+        ip;
+      return { name, ip };
+    }
+  } catch {
+    // not an eSCL scanner
+  }
+
+  return null;
+}
+
+/**
  * Browse mDNS for candidate devices during the given duration.
  * Plain `_http._tcp` alone would return every web-enabled gadget on the
  * network, so several printer-flavoured service types are watched too.
@@ -63,7 +171,21 @@ function browseCandidates(timeoutMs: number): Promise<DiscoveredDevice[]> {
       bonjour.destroy();
       resolve([...candidates.values()]);
     };
-    const timer = setTimeout(finish, timeoutMs);
+
+    const browsers: BonjourBrowser[] = [];
+    const startAll = () => {
+      for (const browser of browsers) {
+        browser.start();
+      }
+    };
+    const stopAllThenRestart = () => {
+      // cold mDNS caches / sleeping devices often miss the very first
+      // multicast query; re-issuing it midway makes discovery reliable
+      for (const browser of browsers) {
+        browser.stop();
+      }
+      startAll();
+    };
 
     for (const type of MDNS_SERVICE_TYPES) {
       const browser = bonjour.find({ type }, (service) => {
@@ -77,9 +199,14 @@ function browseCandidates(timeoutMs: number): Promise<DiscoveredDevice[]> {
           candidates.set(ipv4, { name: service.name, ip: ipv4 });
         }
       });
-      browser.start();
+      browsers.push(browser);
     }
 
+    startAll();
+    const requeryAt = Math.min(timeoutMs / 2, 3000);
+    const requeryTimer = setTimeout(stopAllThenRestart, requeryAt);
+    requeryTimer.unref();
+    const timer = setTimeout(finish, timeoutMs);
     timer.unref();
   });
 }
@@ -123,11 +250,20 @@ export async function discoverCmd(options: DiscoverOptions): Promise<number> {
   const devices = candidates.filter((_, index) => checks[index]);
   devices.sort((a, b) => a.name.localeCompare(b.name));
 
-  if (devices.length === 0) {
+  // mDNS can miss printers that do not answer multicast (VLAN, AP filters);
+  // fall back to probing HP neighbours already known to the OS (ARP cache)
+  const finalDevices =
+    devices.length > 0 || options.name !== undefined
+      ? devices
+      : (await scanKnownArpNeighbours()).sort((a, b) =>
+          a.name.localeCompare(b.name),
+        );
+
+  if (finalDevices.length === 0) {
     console.error("No HP scan-capable device found");
     return 1;
   }
 
-  printDevices(devices, options.json);
+  printDevices(finalDevices, options.json);
   return 0;
 }


### PR DESCRIPTION
## Summary

Overhaul of the Windows NSIS installer and its supporting CI/scripts:

- Installer now asks for the printer IP address and a destination label (the name shown on the printer screen, pre-filled with hostname) instead of fragile network discovery.
- Branding neutralised: display name "node-hp-scan-to", non-affiliation disclaimer, MIT license page.
- Stops any running task/service before overwriting the binary, so a re-install no longer fails on a locked file.
- Binary metadata (icon/publisher/version) embedded via bun --windows-*.
- scripts/build-installer.ps1 + scripts/sign-local.ps1 for local builds and self-signed testing.
- CI: upload installer as artifact + optional SignPath signing (test/release policies).
- discover: re-issue mDNS query mid-window so sleeping printers are found.

## Why

The previous discovery-based device page was unreliable across managed networks and was replaced with an explicit IP entry - simple, deterministic, and good enough for most users (the app itself keeps mDNS name lookup / config fallbacks at runtime).

## Notes

- Windows App Control / SAC on the author's machine blocks launching unsigned installer stubs; final delivery relies on SignPath signing (open-source free tier), wired in the workflow (SIGNPATH_API_TOKEN secret required).
- build-binaries.sh / build-installer.ps1 also emit the new fixed metadata.
