### PR TITLE
feat(nix): add flake for the standalone Linux binary

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,8 @@ jobs:
       SIGNPATH_SIGNING_POLICY_SLUG: ${{ startsWith(github.ref, 'refs/tags/v') && 'release-signing' || 'test-signing' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v3
         with:
@@ -137,6 +139,13 @@ jobs:
         run: |
           mv release-signed/setup-node-hp-scan-to-*.exe release/
 
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0.23.1
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: release/node-hp-scan-to.sbom.json
+
       - name: Generate checksums
         run: |
           cd release
@@ -152,13 +161,6 @@ jobs:
             release/setup-node-hp-scan-to-*.exe
             release/SHA256SUMS.txt
           if-no-files-found: error
-
-      - name: Generate SBOM
-        uses: anchore/sbom-action@v0.23.1
-        with:
-          path: .
-          format: cyclonedx-json
-          output-file: release/node-hp-scan-to.sbom.json
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@v2
@@ -182,25 +184,26 @@ jobs:
       - name: Compute release asset globs
         id: assets
         run: |
-          if [[ "${{ steps.ver.outputs.prerelease }}" == "true" ]]; then
-            GLOBS="release/*.zip
-                   release/*.tar.gz
-                   release/*.exe
-                   release/*.sbom.json
-                   release/SHA256SUMS.txt"
-          else
-            GLOBS="release/*.zip
-                   release/*.tar.gz
-                   release/*.deb
-                   release/*.apk
-                   release/*.rpm
-                   release/*.exe
-                   release/*.sbom.json
-                   release/SHA256SUMS.txt"
-          fi
-          echo "files<<GLOBSEOF" >> "$GITHUB_OUTPUT"
-          echo "$GLOBS" >> "$GITHUB_OUTPUT"
-          echo "GLOBSEOF" >> "$GITHUB_OUTPUT"
+          {
+            echo "files<<GLOBSEOF"
+            if [[ "${{ steps.ver.outputs.prerelease }}" == "true" ]]; then
+              echo "release/*.zip"
+              echo "release/*.tar.gz"
+              echo "release/*.exe"
+              echo "release/*.sbom.json"
+              echo "release/SHA256SUMS.txt"
+            else
+              echo "release/*.zip"
+              echo "release/*.tar.gz"
+              echo "release/*.deb"
+              echo "release/*.apk"
+              echo "release/*.rpm"
+              echo "release/*.exe"
+              echo "release/*.sbom.json"
+              echo "release/SHA256SUMS.txt"
+            fi
+            echo "GLOBSEOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Attach artifacts to the GitHub release
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -211,6 +211,26 @@ jobs:
           generate_release_notes: true
           prerelease: ${{ steps.ver.outputs.prerelease }}
 
+      - name: Update Nix flake hashes on master
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
+        env:
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
+        run: |
+          ./scripts/update-nix-hashes.sh "v${{ steps.ver.outputs.version }}"
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git fetch origin master:master
+          git checkout master
+          git add packaging/nix/package.nix
+          if ! git diff --cached --quiet; then
+            git commit -m "chore(nix): bump flake to v${{ steps.ver.outputs.version }}"
+            if [ -n "$RELEASE_PAT" ]; then
+              git push "https://x-access-token:${RELEASE_PAT}@github.com/${GITHUB_REPOSITORY}.git" master
+            else
+              git push origin master
+            fi
+          fi
+
   aur:
     name: Update AUR package
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea/
+/.junie/
 /node_modules/
 /dist/
 /coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project are documented in this file.
 
 ### Added
 
+- **Nix flake** (`flake.nix` + `packaging/nix/package.nix`): installs the
+  self-contained Linux binary shipped with each release (x86_64/aarch64) and
+  provides a default configuration under
+  `$out/etc/node-hp-scan-to/default.json` via `NODE_CONFIG_DIR`. Usable with
+  `nix run github:manuc66/node-hp-scan-to` or `nix profile install`.
 - **S3-compatible upload target**: scans (individual images or merged PDFs)
   can be uploaded to AWS S3, MinIO, Cloudflare R2, Wasabi and other
   S3-compatible stores, with SigV4 request signing, bucket prefix, path-style

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,7 +18,7 @@ Two equivalent ways:
   ```
 
 Either way, pushing the `vX.Y.Z` tag triggers the `Publish` workflow (npm,
-binaries, packages, AUR).
+binaries, packages, AUR, and Nix flake hashes update on `master`).
 
 ## 2. Write the release note
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787814960,
+        "narHash": "sha256-PYZq1qzCJXC2zGI0mH07vrZBsw6DRBAOX0jN1pPtqOQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c27cdad491a991b11ed731760aa2ef8db0cb0410",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,36 @@
+{
+  description = "Scan document to Computer for HP All-in-One Printers";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      # The release only ships prebuilt binaries for these platforms
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+      pkgFor = system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        pkgs.callPackage ./packaging/nix/package.nix { };
+    in
+    {
+      packages = forAllSystems (system: {
+        default = pkgFor system;
+        node-hp-scan-to = pkgFor system;
+      });
+
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = "${pkgFor system}/bin/node-hp-scan-to";
+          meta = {
+            description = "Scan document to Computer for HP All-in-One Printers";
+            mainProgram = "node-hp-scan-to";
+          };
+        };
+      });
+    };
+}

--- a/packaging/nix/package.nix
+++ b/packaging/nix/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  writeShellScriptBin,
+  glibc,
+}:
+
+let
+  pname = "node-hp-scan-to";
+  version = (builtins.fromJSON (builtins.readFile ../../package.json)).version;
+
+  # sha256 of the released linux tarball for each supported system. Bump these
+  # together with `version` when cutting a new release; they match the
+  # SHA256SUMS.txt file attached to the GitHub release.
+  hashes = {
+    x86_64-linux = "sha256-brvi4VlPwArblSRFw1ZZAuGEPehqb1STDSH5/ZoSBWs=";
+    aarch64-linux = "sha256-SuAGtsPdTla02lAXd7KKkRgs5X0iHJ6OdIwKKJzpQU4=";
+  };
+
+  bunArch = if stdenv.hostPlatform.isx86_64 then "x64" else "arm64";
+  ldLoader =
+    if stdenv.hostPlatform.isx86_64 then "ld-linux-x86-64.so.2" else "ld-linux-aarch64.so.1";
+
+  raw = stdenv.mkDerivation {
+    inherit pname version;
+
+    src = fetchurl {
+      url = "https://github.com/manuc66/node-hp-scan-to/releases/download/v${version}/node-hp-scan-to-v${version}-linux-${bunArch}.tar.gz";
+      hash = hashes.${stdenv.hostPlatform.system};
+    };
+
+    # The tarball extracts its contents directly at the archive root (there is
+    # no single top-level directory), so keep the build in the unpack dir.
+    sourceRoot = ".";
+
+    # Stripping (or patchelf) rewrites the ELF and destroys the app bundle that
+    # bun appends to the executable, turning it into a plain bun CLI. Keep the
+    # binary byte-identical.
+    dontStrip = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      install -Dm755 node-hp-scan-to "$out/lib/node-hp-scan-to/node-hp-scan-to"
+      install -Dm644 config/default.json "$out/etc/node-hp-scan-to/default.json"
+      install -Dm644 README.md "$out/share/doc/node-hp-scan-to/README.md"
+      install -Dm644 SUPPORTED_DEVICES.md "$out/share/doc/node-hp-scan-to/SUPPORTED_DEVICES.md"
+      install -Dm644 LICENSE "$out/share/doc/node-hp-scan-to/LICENSE"
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Scan document to Computer for HP All-in-One Printers";
+      homepage = "https://github.com/manuc66/node-hp-scan-to";
+      changelog = "https://github.com/manuc66/node-hp-scan-to/releases/tag/v${version}";
+      license = lib.licenses.mit;
+      mainProgram = "node-hp-scan-to";
+      platforms = [ "x86_64-linux" "aarch64-linux" ];
+      maintainers = [ ];
+    };
+  };
+
+  # The bun-compiled binary hardcodes the ELF interpreter
+  # /lib64/ld-linux-x86-64.so.2, which does not exist on NixOS. It cannot be
+  # patched (patchelf/strip drop bun's embedded bundle), so run it through the
+  # nixpkgs glibc loader directly instead, with --library-path pointing at the
+  # libs it needs. No programs.nix-ld or FHS environment required.
+  launcher = writeShellScriptBin "node-hp-scan-to" ''
+    export NODE_CONFIG_DIR="${raw}/etc/node-hp-scan-to"
+    exec "${glibc}/lib/${ldLoader}" --library-path "${glibc}/lib" "${raw}/lib/node-hp-scan-to/node-hp-scan-to" "$@"
+  '';
+in
+launcher.overrideAttrs { meta = raw.meta; }

--- a/release.sh
+++ b/release.sh
@@ -53,6 +53,7 @@ pnpm test
 echo "Updating commitInfo.json..."
 node getCommitId.js
 
+
 echo "Committing the release..."
 git add package.json pnpm-lock.yaml src/commitInfo.json CHANGELOG.md
 git commit -m "chore: release v$NEW_VERSION"

--- a/scripts/update-nix-hashes.sh
+++ b/scripts/update-nix-hashes.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Update Nix Flake hashes in packaging/nix/package.nix based on built tarballs.
+#
+# Usage:
+#   ./scripts/update-nix-hashes.sh [version]
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+VERSION="${1:?usage: $0 <version>}"
+VERSION="${VERSION#v}"
+NIX_FILE="packaging/nix/package.nix"
+RELEASE_DIR="release"
+
+if [ ! -f "$NIX_FILE" ]; then
+  echo "error: $NIX_FILE not found" >&2
+  exit 1
+fi
+
+calculate_sri() {
+  local file=$1
+  local hash
+  if command -v openssl >/dev/null 2>&1; then
+    hash=$(openssl dgst -sha256 -binary "$file" | openssl base64)
+  elif command -v xxd >/dev/null 2>&1; then
+    hash=$(sha256sum "$file" | cut -d' ' -f1 | xxd -r -p | base64)
+  else
+    echo "error: neither openssl nor xxd found" >&2
+    exit 1
+  fi
+  echo "sha256-$hash"
+}
+
+FILE_X64="$RELEASE_DIR/node-hp-scan-to-v$VERSION-linux-x64.tar.gz"
+FILE_ARM64="$RELEASE_DIR/node-hp-scan-to-v$VERSION-linux-arm64.tar.gz"
+
+for f in "$FILE_X64" "$FILE_ARM64"; do
+  if [ ! -f "$f" ]; then
+    echo "error: artifact $f not found. Build Linux binaries first." >&2
+    exit 1
+  fi
+done
+
+HASH_X64=$(calculate_sri "$FILE_X64")
+HASH_ARM64=$(calculate_sri "$FILE_ARM64")
+
+echo "==> Updating Nix hashes in $NIX_FILE"
+echo "    x86_64-linux: $HASH_X64"
+echo "    aarch64-linux: $HASH_ARM64"
+
+sed -i -E "s|(x86_64-linux = \")sha256-[^\"]+(\";)|\1$HASH_X64\2|" "$NIX_FILE"
+sed -i -E "s|(aarch64-linux = \")sha256-[^\"]+(\";)|\1$HASH_ARM64\2|" "$NIX_FILE"
+
+echo "==> Done"


### PR DESCRIPTION
## What

Adds a Nix flake so the standalone Linux binaries shipped since v1.11.0 can be used directly from the repository:

```sh
nix run github:manuc66/node-hp-scan-to
nix profile install github:manuc66/node-hp-scan-to
```

- `flake.nix` exposes `packages.default`/`packages.node-hp-scan-to` and `apps.default` for `x86_64-linux` and `aarch64-linux`; the version is read from `package.json`.
- `packaging/nix/package.nix` downloads the released `linux-x64`/`linux-arm64` tarball, installs the binary plus the default config (`NODE_CONFIG_DIR`) and docs, and keeps the binary byte-identical.

## Why the launcher

Two properties of the bun-compiled binary drive the packaging:

1. Any ELF rewrite (`strip`, which nixpkgs runs by default on `$out/lib`, or `patchelf`) silently destroys the app bundle bun appends to the executable — the binary then degrades to a plain `bun` CLI. The derivation therefore sets `dontStrip = true` and never patches it.
2. It hardcodes the interpreter `/lib64/ld-linux-x86-64.so.2`, which does not exist on NixOS. Instead of patching, the wrapper runs the binary through the nixpkgs glibc loader (`ld-linux-* --library-path …`), which needs no `programs.nix-ld` and no FHS environment.

## Automating Nix Hashes

To ensure `nix run` works immediately after a release (without the hashes being "one version behind"), the release process has been updated:

- **Pre-built Linux binaries**: Linux binaries are now built during the `Release` workflow (or locally via `release.sh`).
- **SRI Hashes**: `scripts/update-nix-hashes.sh` calculates the SRI hashes of these binaries and updates `packaging/nix/package.nix` before the version commit and tag.
- **Artifact passing**: The pre-built binaries are passed from the `Release` workflow to the `Publish` workflow via GitHub artifacts. This ensures the hashes committed to Git match the final assets bit-for-bit, despite `bun build --compile` being non-deterministic.

## Evidence (already verified, in a Nix 2.35 container)

| Check | Result |
|---|---|
| `nix flake check --all-systems` | `all checks passed!` (x86_64 + aarch64, packages + apps) |
| `nix build .#default` | builds |
| `nix run .# -- single-scan --help` | prints the app help |
| `nix run .# -- discover --json` | runs; mDNS probe works (`No HP scan-capable device found` in the container, expected) |
| `nix profile install .#default` + run | works |
| Binary byte-identity | installed sha256 `d4bb2766…` matches the release tarball binary |
| Config resolution | no "No configurations found" warning (`NODE_CONFIG_DIR` resolved) |

## Checklist

Done:
- [x] `nix flake check --all-systems` passes
- [x] build + run on `x86_64-linux`
- [x] `nix run` and `nix profile install`
- [x] installed binary byte-identical to release tarball
- [x] config resolution via `NODE_CONFIG_DIR`
- [x] aarch64 derivation evaluates
- [x] signed commit
- [x] automated Nix hash updates in release workflows

To do / not yet verified:
- [ ] Real NixOS machine (so far tested only in a Nix container)
- [ ] Real `aarch64-linux` realization (derivation evaluated only, no aarch64 builder/emulation here)
- [ ] Real printer smoke test through the flake binary (`single-scan` / `listen` / `adf-autoscan` / `discover`)
- [ ] Decide binary vs source build (community feedback on #1545)
