### PR TITLE
fix(logger): run pino-pretty in-process under Bun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ All notable changes to this project are documented in this file.
   in-process (the same path already used for the plain/service mode);
   Node.js keeps the worker transport.
 
+### Added
+
+- Tests guarding the Bun pretty-mode regression: a unit test for the
+  in-process/worker decision plus an integration test that compiles a real
+  Bun executable and runs it in `LOG_FORMAT=pretty` (skipped when bun is not
+  installed).
+
 ## [1.11.0] - 2026-08-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented in this file.
 
 > **Note:** all public communication on this repository is done in English.
 
+## [Unreleased]
+
+### Fixed
+
+- **Standalone executables**: in interactive terminals the `pretty` log mode
+  crashed with `unable to determine transport target for "pino-pretty"`. A
+  compiled Bun binary bundles every module, so the pino worker-thread
+  transport cannot resolve its target at runtime. Bun now runs pino-pretty
+  in-process (the same path already used for the plain/service mode);
+  Node.js keeps the worker transport.
+
 ## [1.11.0] - 2026-08-29
 
 ### Added

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -86,9 +86,15 @@ const loggerOptions = {
 // pino-pretty in-process there (the messageFormat below cannot cross a
 // worker boundary anyway). Node.js keeps the worker transport.
 // process.isBun is only defined under Bun, so it is not part of @types/node.
-const isBun =
-  typeof (process as { isBun?: boolean }).isBun === "boolean" &&
-  (process as { isBun?: boolean }).isBun;
+const isBun = (process as { isBun?: boolean }).isBun === true;
+
+export function shouldUseInProcessPinoPretty(
+  isPlain: boolean,
+  isPretty: boolean,
+  isBun: boolean,
+): boolean {
+  return isPlain || (isPretty && isBun);
+}
 
 const prettyOptions = isPlain
   ? {
@@ -112,24 +118,23 @@ const prettyOptions = isPlain
       ignore: "pid,hostname",
     };
 
-const baseLogger: Logger =
-  isPlain || (isPretty && isBun)
-    ? pino(loggerOptions, pinoPretty(prettyOptions))
-    : pino({
-        ...loggerOptions,
-        ...(isPretty
-          ? {
-              transport: {
-                target: "pino-pretty",
-                options: {
-                  colorize: isCli,
-                  translateTime: "HH:MM:ss.l",
-                  ignore: "pid,hostname",
-                },
+const baseLogger: Logger = shouldUseInProcessPinoPretty(isPlain, isPretty, isBun)
+  ? pino(loggerOptions, pinoPretty(prettyOptions))
+  : pino({
+      ...loggerOptions,
+      ...(isPretty
+        ? {
+            transport: {
+              target: "pino-pretty",
+              options: {
+                colorize: isCli,
+                translateTime: "HH:MM:ss.l",
+                ignore: "pid,hostname",
               },
-            }
-          : {}),
-      });
+            },
+          }
+        : {}),
+    });
 
 export function setDebugLevel(isDebug: boolean): void {
   baseLogger.level = isDebug ? "debug" : defaultLevel;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -81,40 +81,55 @@ const loggerOptions = {
   },
 };
 
-const baseLogger: Logger = isPlain
-  ? // In-process pino-pretty (no worker thread): the messageFormat function
-    // cannot cross a worker boundary. Keeps legacy bare info/debug lines and
-    // prefixes warn/error/fatal so humans can tell severity apart.
-    pino(
-      loggerOptions,
-      pinoPretty({
-        colorize: false,
-        singleLine: true,
-        ignore: "pid,hostname,time,level,name",
-        messageFormat: (log: Record<string, unknown>, messageKey: string) => {
-          const msg = log[messageKey] as string;
-          const levelLabel = LEVEL_LABELS[log["level"] as number] ?? "info";
-          return levelLabel === "info" || levelLabel === "debug"
-            ? msg
-            : `${levelLabel.toUpperCase()}: ${msg}`;
-        },
-      }),
-    )
-  : pino({
-      ...loggerOptions,
-      ...(isPretty
-        ? {
-            transport: {
-              target: "pino-pretty",
-              options: {
-                colorize: isCli,
-                translateTime: "HH:MM:ss.l",
-                ignore: "pid,hostname",
+// Bun-compiled executables bundle every module, so a pino worker-thread
+// transport cannot resolve its "pino-pretty" target at runtime. Run
+// pino-pretty in-process there (the messageFormat below cannot cross a
+// worker boundary anyway). Node.js keeps the worker transport.
+// process.isBun is only defined under Bun, so it is not part of @types/node.
+const isBun =
+  typeof (process as { isBun?: boolean }).isBun === "boolean" &&
+  (process as { isBun?: boolean }).isBun;
+
+const prettyOptions = isPlain
+  ? {
+      // Keeps legacy bare info/debug lines and prefixes warn/error/fatal so
+      // humans can tell severity apart.
+      colorize: false,
+      singleLine: true,
+      ignore: "pid,hostname,time,level,name",
+      messageFormat: (log: Record<string, unknown>, messageKey: string) => {
+        const msg = log[messageKey] as string;
+        const levelLabel = LEVEL_LABELS[log["level"] as number] ?? "info";
+        return levelLabel === "info" || levelLabel === "debug"
+          ? msg
+          : `${levelLabel.toUpperCase()}: ${msg}`;
+      },
+    }
+  : {
+      colorize: isCli,
+      singleLine: true,
+      translateTime: "HH:MM:ss.l",
+      ignore: "pid,hostname",
+    };
+
+const baseLogger: Logger =
+  isPlain || (isPretty && isBun)
+    ? pino(loggerOptions, pinoPretty(prettyOptions))
+    : pino({
+        ...loggerOptions,
+        ...(isPretty
+          ? {
+              transport: {
+                target: "pino-pretty",
+                options: {
+                  colorize: isCli,
+                  translateTime: "HH:MM:ss.l",
+                  ignore: "pid,hostname",
+                },
               },
-            },
-          }
-        : {}),
-    });
+            }
+          : {}),
+      });
 
 export function setDebugLevel(isDebug: boolean): void {
   baseLogger.level = isDebug ? "debug" : defaultLevel;

--- a/test/asset/bun-logger-entry.ts
+++ b/test/asset/bun-logger-entry.ts
@@ -1,0 +1,7 @@
+// Compiled by the bun integration test (test/bun-compiled-logger.test.ts)
+// into a standalone executable. Verifies that a bun-compiled binary can log
+// in pretty mode without crashing.
+import { getLoggerForFile } from "../../src/logger.js";
+
+const log = getLoggerForFile(import.meta.url);
+log.info("hello from a bun-compiled executable");

--- a/test/bun-compiled-logger.test.ts
+++ b/test/bun-compiled-logger.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, before, after } from "mocha";
+import { expect } from "chai";
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// The regression this test guards against (see issue #1688): a bun-compiled
+// executable bundles every module, so pino's worker-thread transport cannot
+// resolve its "pino-pretty" target at runtime and the process crashes with
+// `unable to determine transport target for "pino-pretty"` in pretty mode.
+// The test compiles a real bun executable and runs it in pretty mode.
+// It is skipped when bun is not available (e.g. on CI jobs that do not
+// install bun), so it runs where it matters: the `binaries` release job and
+// developer machines with bun installed.
+
+const hasBun = (() => {
+  try {
+    execFileSync("bun", ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+const describeWithBun = hasBun ? describe : describe.skip;
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const entry = path.join(repoRoot, "test", "asset", "bun-logger-entry.ts");
+
+describeWithBun("bun-compiled executable logging", () => {
+  const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "bun-logger-test-"));
+  const binary = path.join(outDir, "bun-logger-test");
+
+  before(() => {
+    // Compile a standalone executable from a tiny entry that logs in pretty
+    // mode. This reproduces the standalone binaries shipped with releases.
+    // No --target is passed so bun compiles for the current host.
+    execFileSync("bun", ["build", "--compile", `--outfile=${binary}`, entry], {
+      stdio: "ignore",
+    });
+  });
+
+  after(() => {
+    fs.rmSync(outDir, { recursive: true, force: true });
+  });
+
+  it("runs in pretty mode without crashing", () => {
+    // NODE_ENV=test (set by setup-env.js for this mocha run) would disable
+    // the logger, so override it for the spawned executable.
+    const res = spawnSync(binary, [], {
+      env: { ...process.env, LOG_FORMAT: "pretty", NODE_ENV: "production" },
+      encoding: "utf8",
+    });
+    expect(res.status).to.equal(0, `exit code ${res.status}\nstderr: ${res.stderr}`);
+    expect(res.stderr).not.to.match(/unable to determine transport target/);
+    // the entry logs an info line which the pretty output must carry
+    expect(res.stdout).to.contain("hello from a bun-compiled executable");
+  });
+});

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -1,0 +1,24 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+import { shouldUseInProcessPinoPretty } from "../src/logger.js";
+
+describe("shouldUseInProcessPinoPretty", () => {
+  it("uses in-process pino-pretty for the plain mode regardless of runtime", () => {
+    expect(shouldUseInProcessPinoPretty(true, false, false)).to.equal(true);
+    expect(shouldUseInProcessPinoPretty(true, true, false)).to.equal(true);
+    expect(shouldUseInProcessPinoPretty(true, true, true)).to.equal(true);
+  });
+
+  it("uses in-process pino-pretty for the pretty mode under Bun (worker transport is not resolvable in compiled binaries)", () => {
+    expect(shouldUseInProcessPinoPretty(false, true, true)).to.equal(true);
+  });
+
+  it("keeps the worker transport for the pretty mode under Node.js", () => {
+    expect(shouldUseInProcessPinoPretty(false, true, false)).to.equal(false);
+  });
+
+  it("uses no transport (plain JSON output) when neither plain nor pretty", () => {
+    expect(shouldUseInProcessPinoPretty(false, false, false)).to.equal(false);
+    expect(shouldUseInProcessPinoPretty(false, false, true)).to.equal(false);
+  });
+});


### PR DESCRIPTION
Fixes the standalone executables crashing with `unable to determine transport target for "pino-pretty"` when run in an interactive terminal (the `pretty` log mode). **Bun-only** — Node.js is not affected.

**Root cause**: `src/logger.ts` configures pino with a worker-thread transport (`transport: { target: "pino-pretty" }`) for the `pretty` mode. In a Bun-compiled binary every module is bundled into the executable, so the transport worker cannot resolve `pino-pretty` at runtime and the process aborts at startup.

**Fix**: under Bun (`process.isBun`), run pino-pretty in-process — the same path already used for the plain/service mode. Node.js keeps the worker transport unchanged.

**Regression tests added** (this should never have shipped):
- `test/logger.test.ts` — unit test of the in-process/worker decision function, run in every CI job.
- `test/bun-compiled-logger.test.ts` + `test/asset/bun-logger-entry.ts` — integration test that compiles a **real Bun executable** and runs it in `LOG_FORMAT=pretty`, asserting it does not crash. Skipped when bun is unavailable (e.g. the `npm`/`docker-image` CI jobs); runs in the `binaries` release job and on machines with bun.

**Proof the tests catch the regression**: with the old behavior simulated, both the unit test (`expected false to equal true`) and the integration test (exit code 1, `unable to determine transport target`) fail; with the fix all pass.

**Verified**: typecheck, lint, 616 tests pass; pretty/TTY/plain/json all work in the compiled binary.