### PR TITLE
docs(capture): reverse-engineer the HP scan-to-PC HTTPS traffic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ packaging/windows/staging/
 /test/asset/sample2.jpg
 /.yarn/install-state.gz
 /rust-version/
+/protocol_doc/capture/tools/driver-store/
+/protocol_doc/capture/tools/hp-mitm-capture/

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Unlike the original HP program, `node-hp-scan-to` is cross-platform and can be r
   - [Configure](#Configure)
 - [Build Source Code](#build-source-code)
   - [Debugging](#debugging)
+- [Reverse Engineering](#reverse-engineering)
 - [💖 Support this project](#-support-this-project)
 - [🙏 Special Thanks](#-special-thanks)
 - [License](#license)
@@ -811,6 +812,12 @@ node dist/index.js -a 192.168.1.5
 I'm using Visual Studio Code to debug this application, so instead of running `tsx`, just run `code .` and press F5 to start debugging.
 
 You may want to set your printers ip or name in `.vscode/launch.json`
+
+## Reverse Engineering
+
+- [Capturing the HP driver network traffic in the clear](protocol_doc/capture/README.md) — how the driver/printer exchanges (including HTTPS) are reverse-engineered: native Windows with mitmproxy (IP redirection) and Linux/Wine with the GnuTLS keylog.
+- [Protocol documentation](protocol_doc/HP%20Officejet%206500%20E710n-z.md) — the reverse-engineered proprietary HP protocols.
+- [eSCL protocol documentation](protocol_doc/HP%20PageWide%20Pro%20477dw%20MFP.md).
 
 ## 💖 Support this project
 

--- a/protocol_doc/capture/README.md
+++ b/protocol_doc/capture/README.md
@@ -1,0 +1,59 @@
+# Capturing the scan-to-PC network traffic
+
+Two validated, reproducible ways to read the proprietary HP driver / printer
+exchanges in the clear. Choose by platform — on Windows, the IP-redirect
+mitmproxy method is the primary one.
+
+## 1. Windows — mitmproxy with IP redirect (recommended)
+
+→ [`native-windows-mitmproxy.md`](native-windows-mitmproxy.md)
+
+One validated on an **HP Smart Tank Plus 570** (see the doc for the
+reference observations). It captures whatever the device really exchanges —
+different devices may use eSCL, a 1st/2nd-gen `WalkupScan`, plain HTTP, or
+nothing of the sort. Works even when the driver daemon ignores the driver ini
+and talks straight to the printer's real IP: it hijacks the printer IPv4 on
+the loopback, binds mitmweb on `IP:443`, forwards `IP:80` via portproxy, and
+reaches the real printer upstream through its IPv6 link-local. Scripted
+end-to-end in `protocol_doc/capture/tools/capture-https-windows.ps1` (setup +
+restore).
+
+## 2. Linux / Wine — GnuTLS keylog, no MITM (validated)
+
+→ [`wine-gnutls-keylog.md`](wine-gnutls-keylog.md)
+
+Run the driver under Wine in an isolated Docker container; an `LD_PRELOAD`
+shim enables `SSLKEYLOGFILE` on Wine's GnuTLS stack, and tshark decrypts the
+pcap (no certificate installation, no MITM). Tools in `protocol_doc/capture/tools/`
+(Dockerfile, `prepare.sh`, `sslkeylog-gnutls.c`, `winhttp-get.c`).
+
+## Getting your bearings first (all methods)
+
+A quick interface capture is the friendlier first step: it shows you the lay
+of the land — which ports/protocols the device uses, and whether any
+multicast-based discovery happens (that only appears during a fresh “add
+printer”, not when the device is already registered) — before you reach for a
+MITM or the GnuTLS patch:
+
+- pointed capture: `host <printer>` — the direct HTTP/HTTPS exchanges;
+- unfiltered interface capture while re-adding the printer — shows the
+  discovery side if the device uses it.
+
+If the flow is already **plain HTTP**, Wireshark alone gives you everything,
+no MITM needed. Captured pcaps / `.flow` dumps contain private details, so
+they stay local (`~/Documents/hp-mitm-capture/`) rather than in the repo.
+
+### Before sharing a dump: what it may contain
+
+A capture rarely carries only the protocol. Before publishing one, make sure
+nothing unrelated travels with it:
+
+- **the scanned pages themselves** — prefer a non-sensitive test page;
+- **the printer**: serial number, model, MAC, IPv6 link-local address;
+- **the PC**: IP address, hostname, MAC (via ARP/DHCP);
+- the `.flow` dumps are already **decrypted** — treat them like plain text;
+  check the request headers for `Authorization`/cookies and redact if present;
+- a capture taken on the whole LAN interface also drags **unrelated traffic**
+  (other devices, the Internet). Share only printer-scoped traffic: capture
+  with `-f "host <printer>"`, and prefer the mitmweb `.flow` dump over a
+  full-interface pcap.

--- a/protocol_doc/capture/native-windows-mitmproxy.md
+++ b/protocol_doc/capture/native-windows-mitmproxy.md
@@ -1,0 +1,238 @@
+# Capturing the HP driver network traffic on native Windows (mitmproxy)
+
+> Reproducible procedure for issue
+> [#1019](https://github.com/manuc66/node-hp-scan-to/issues/1019): on a
+> native Windows machine, capture (a) the printer exchanges and (b) the
+> proprietary HP driver HTTPS exchanges in the
+> **clear**, using **mitmproxy**. Everything is scripted in
+> `protocol_doc/capture/tools/capture-https-windows.ps1`; the steps below can also
+> be done by hand.
+
+This is the recommended, validated way on native Windows: the HP driver
+connects **directly to the printer IP** (it ignores the system proxy), so a
+classic forward proxy does not help.
+
+> Native Windows **SChannel does not support `SSLKEYLOGFILE`**, which is why
+> this MITM approach is required on Windows. Under Linux/Wine, the
+> `LD_PRELOAD` GnuTLS shim from this repo (`sslkeylog-gnutls.c`) is the
+> alternative — no certificate install needed.
+
+## Reference observations (HP Smart Tank Plus 570 — one device)
+
+> Device-dependent — not all devices expose eSCL or `WalkupScan*`. What a
+> capture contains depends on the device; treat these as one data point.
+
+On the tested ST570:
+
+- The `NetworkDevices\<SERIAL>.ini` is configured with `PortNumber=80`
+  (**plain HTTP**) for the control plane: `DevMgmt/DiscoveryTree.xml`,
+  `WalkupScanToCompCaps`, `WalkupScanToCompDestinations` (GET/POST/DELETE),
+  `EventMgmt/EventTable?timeout=1200` (long-poll) and
+  `WalkupScanToCompEvent`.
+- The **scan-to-PC job flow runs over HTTPS on 443** in this capture:
+  `POST /eSCL/ScanJobs → 201`, `GET /eSCL/ScanJobs/<id>/NextDocument` (the
+  scanned page image, e.g. ~74 kB JPEG), `GET /eSCL/ScanJobs/<id>/ScanImageInfo`,
+  `GET /eSCL/ScannerStatus`, `GET /eSCL/eSCLConfig`.
+- **The daemon ignores the ini IP address at runtime** → the classic ini
+  redirect (`IPAddress=127.0.0.1`) does **not** intercept it; it keeps
+  talking to the real printer IP. Capturing therefore requires redirecting at
+  the **IP/route level** (Step 2, mode `-IpRedirect`).
+
+## Result you get
+
+- **Traffic pcap**: a Wireshark/tshark capture of the printer exchanges
+  (`host <printer>`) — readable directly, no keys.
+- **HTTPS**: every request/response the driver actually exchanges with the
+  device, decrypted in the mitmweb UI, replayable `.flow` dumps plus
+  extracted response bodies. What those requests are depends on the device
+  (eSCL, `WalkupScan`/`WalkupScanToComp`, or neither).
+
+## Prerequisites
+
+1. **Windows 10/11, PowerShell 5.1+** — the script uses Windows cmdlets
+   (`Get-NetIPInterface`, `New-NetIPAddress`) and `netsh`.
+2. **The HP application installed** on this machine (the driver daemon that
+   generates the traffic to capture).
+3. **Wireshark** (bundles Npcap) — clear-text capture.
+4. **mitmproxy 12+** (binary installer, or `pip install mitmproxy`). The script
+   finds `mitmweb.exe` automatically (default
+   `C:\Program Files\mitmproxy\bin\mitmweb.exe`). The bundled Python covers
+   `export-flows.py` (run via `mitmdump -s`); no separate Python install
+   needed.
+5. **Administrator rights** — to add the route/IP, the CA import and the
+   portproxy. The script self-elevates via UAC; alternatively use
+   **gsudo** (`winget install -e --id gerardog.gsudo`):
+
+   > After installing gsudo, refresh the `PATH` or open a new terminal:
+   > ```powershell
+   > $env:Path = [Environment]::GetEnvironmentVariable("Path","User") + ";" + [Environment]::GetEnvironmentVariable("Path","Machine")
+   > ```
+6. The printer **IPv4 address** (the IPv6 link-local for the upstream is read
+   automatically from the ini, or passed with `-PrinterIPv6`).
+
+## Step 1 — Check the transport (before redirecting)
+
+Driver still configured normally; nothing changed yet. A quick capture of
+everything to/from the printer is worth it first — it shows which ports are
+used, and whether the device does any multicast-based discovery (only visible
+during a fresh “add printer” in the app):
+
+```powershell
+Get-NetAdapter | Where-Object Status -eq Up            # pick the LAN interface
+& "$env:ProgramFiles\Wireshark\tshark.exe" -i "Ethernet" `
+  -f "host <PRINTER_IP>" `
+  -w "$PWD\capture.pcap"
+```
+
+Trigger printer activity in the HP application (re-detect the printer, run a
+scan), then Ctrl+C. Check which ports appear: `80`/`8080` = plain HTTP,
+`443` = HTTPS. On the reference ST570 the HTTPS (443) eSCL flow was the one
+needing decryption.
+
+## Step 2 — Capture with IP redirection (recommended; validated)
+
+This hijacks the printer's IPv4 **on this machine** (loopback route + the IP
+assigned locally), binds mitmweb on `<PRINTER_IP>:443`, forwards `<PRINTER_IP>:80`
+via portproxy to a local HTTP reverse proxy, and forwards upstream to the
+**real printer over its IPv6 link-local** (so there is no loop). The real
+printer is untouched — only outbound connections from this PC are captured.
+
+```powershell
+cd <repo>
+gsudo powershell -ExecutionPolicy Bypass -File .\protocol_doc\capture\tools\capture-https-windows.ps1 `
+  -IpRedirect -PrinterIP 192.168.129.21
+
+# or let the script self-elevate via UAC:
+powershell -ExecutionPolicy Bypass -File .\protocol_doc\capture\tools\capture-https-windows.ps1 `
+  -IpRedirect -PrinterIP 192.168.129.21
+```
+
+What it does, in order:
+
+1. Kills any stale `mitmweb` from a previous session.
+2. Reads the printer IPv6 link-local from the ini (override: `-PrinterIPv6 fe80::…`),
+   and the driver config path (override: `-ConfigIni <path>`).
+3. Assigns the printer IP to the loopback interface + an on-link route
+   (`192.168.129.21/32` on the loopback) — the daemon's connections to that
+   IP now land on this machine.
+4. Starts `mitmweb` **bound to `<PRINTER_IP>:443`** in reverse mode
+   (`--mode reverse:https://[fe80::…] --ssl-insecure --set connection_strategy=lazy`).
+   Binding the hijacked IP directly makes the presented leaf cert
+   `CN=<PRINTER_IP>` (name verification passes).
+5. Starts a second `mitmweb` on `127.0.0.1:8444` as reverse HTTP
+   (`reverse:http://[fe80::…]`) + `netsh portproxy` forwarding
+   `<PRINTER_IP>:80 → 127.0.0.1:8444` (plain HTTP needs no correct-name cert).
+6. Imports the mitmproxy CA into `Cert:\LocalMachine\Root` (fallback
+   `Cert:\CurrentUser\Root`).
+7. Writes the session `README.txt` (UI tokens) to `$PWD\hp-mitm-capture\`.
+
+### Quick check it's armed
+
+```powershell
+Get-NetRoute -DestinationPrefix "192.168.129.21/32"   # route present
+netstat -ano | Select-String "192.168.129.21:443"      # mitmweb listening
+Get-NetIPAddress 192.168.129.21                         # IP on loopback
+```
+
+## Step 3 — Trigger, read, save
+
+1. **Restart the HP application** (`ScanToPCActivationApp.exe` / “HP Scan”).
+2. Open the mitmweb UIs with the printed tokens:
+   - HTTPS events: http://127.0.0.1:8081
+   - HTTP events:  http://127.0.0.1:8082
+3. Trigger a scan / device events from the printer panel. The requests the
+   device actually uses appear **decrypted** in mitmweb (on the ST570 above:
+   `POST /eSCL/ScanJobs` then `NextDocument` page image).
+4. **Save the flows** (mitmweb keeps them in memory). Export both instances
+   to `.flow` dumps (replayable, kept outside the repository):
+
+```powershell
+$dir = "C:\Users\<you>\Documents\hp-mitm-capture\capture-$(Get-Date -Format yyyy-MM-dd)"
+New-Item -ItemType Directory -Force $dir | Out-Null
+curl.exe -s "http://127.0.0.1:8081/flows/dump?token=<TOKEN_HTTPS>" -o "$dir\https-scan-to-pc.flow"
+curl.exe -s "http://127.0.0.1:8082/flows/dump?token=<TOKEN_HTTP>"  -o "$dir\http-control.flow"
+```
+
+5. **Extract the readable bodies** (scanned pages, XML) from the dumps:
+
+```powershell
+& "C:\Program Files\mitmproxy\bin\mitmdump.exe" -q -n -r "$dir\https-scan-to-pc.flow" -s $repo\protocol_doc\capture\tools\export-flows.py
+& "C:\Program Files\mitmproxy\bin\mitmdump.exe" -q -n -r "$dir\http-control.flow"  -s $repo\protocol_doc\capture\tools\export-flows.py
+# → wrote exported\summary.txt + exported\resp_<ts>_GET_....img/xml/text
+```
+
+Re-open a dump later in the UI: `mitmweb -r "$dir\https-scan-to-pc.flow"`.
+
+## Step 4 — Restore
+
+```powershell
+gsudo powershell -ExecutionPolicy Bypass -File .\protocol_doc\capture\tools\capture-https-windows.ps1 -Restore
+```
+
+It removes the loopback route/IP and the portproxy rule, desinstalls the
+mitmproxy CA, kills the mitmweb processes, and repairs the
+driver ini if it was left pointing at `127.0.0.1`. The HP application is
+**not** restarted — do it manually, then re-detect the printer.
+
+> Note: the HP application can rewrite `NetworkDevices\*.ini` by itself while
+> a session is edited. On restore, the script deliberately picks the newest
+> backup that points at a **real IP** (not `127.0.0.1`).
+
+## Script parameters
+
+| Parameter | Meaning |
+| --- | --- |
+| `-PrinterIP <ip>` | printer IPv4 to hijack |
+| `-PrinterIPv6 <fe80::…>` | upstream printer; else read from the ini |
+| `-ConfigIni <path>` | explicit driver ini path |
+| `-MitmwebPath <exe>` | explicit mitmweb binary |
+| `-WebPort 8081` | HTTPS UI port |
+| `-WebPortHttp 8082` | HTTP UI port |
+| `-HttpProxyPort 8444` | local HTTP reverse-proxy port (portproxy target) |
+| `-Restore` | revert everything for the current mode |
+| `-SkipElevate` | do not self-elevate (already elevated / testing) |
+
+## Manual (no-script) equivalent
+
+```powershell
+# 1. hijack the printer IP locally (admin)
+Get-NetIPInterface | Where-Object InterfaceAlias -like "*loopback*" | % IFaceIndex = 1
+New-NetIPAddress -InterfaceIndex 1 -IPAddress 192.168.129.21 -PrefixLength 32
+Get-NetRoute -DestinationPrefix "192.168.129.21/32" -ErrorAction SilentlyContinue
+
+# 2. HTTPS reverse proxy bound on the printer IP; upstream via IPv6 link-local
+mitmweb --listen-host 192.168.129.21 --listen-port 443 `
+  --mode "reverse:https://[fe80::5281:40ff:fe69:27cc]" --ssl-insecure `
+  --set connection_strategy=lazy --set web_password=<token>
+
+# 3. HTTP kept working via portproxy (admin)
+mitmweb --listen-host 127.0.0.1 --listen-port 8444 `
+  --mode "reverse:http://[fe80::5281:40ff:fe69:27cc]" --ssl-insecure
+netsh interface portproxy add v4tov4 listenaddress=192.168.129.21 listenport=80 `
+  connectaddress=127.0.0.1 connectport=8444
+
+# 4. trust the CA (admin)
+Import-Certificate -FilePath "$HOME\.mitmproxy\mitmproxy-ca-cert.pem" `
+  -CertStoreLocation Cert:\LocalMachine\Root
+```
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+| --- | --- |
+| `gsudo` not recognized | PATH not refreshed — re-open the terminal or refresh `$env:Path`. |
+| Script stops at “Requesting administrator rights” | UAC declined — accept it, or run through `gsudo`. |
+| Nothing flows into mitmweb during the scan | Daemon talking to the real IP but not intercepted: verify the loopback route + `netstat` listener (Step 2 “Verify”). |
+| mitmweb UI: “403 Authentication Required” | Use the token printed by the script / in the session `README.txt`. |
+| Old mitmweb still holds the port | The script kills stale `mitmweb` at startup; move on. |
+| Driver refuses the certificate | CA not imported: check `certmgr.msc` → Trusted Root → “mitmproxy”, re-run elevated. If it still refuses, the driver may **pin** the printer’s certificate — the device accepts a self-signed one, so pinning is unlikely, but if present only a switch/firmware-level capture can help. |
+| Restore re-applies a `127.0.0.1` ini | The app rewrote the ini during capture; run `-Restore` again after closing the HP app. |
+| Port 8081/8082 already used | Pass `-WebPort`/`-WebPortHttp` to different ports. |
+
+## Related files
+
+- `protocol_doc/capture/tools/capture-https-windows.ps1` — setup/restore.
+- `protocol_doc/capture/tools/export-flows.py` — extract readable bodies from `.flow`.
+- `protocol_doc/capture/wine-gnutls-keylog.md` — the Wine/Linux
+  alternative (GnuTLS `LD_PRELOAD` keylog, no MITM).
+- `protocol_doc/capture/README.md` — index: pick your method.

--- a/protocol_doc/capture/tools/Dockerfile
+++ b/protocol_doc/capture/tools/Dockerfile
@@ -1,0 +1,53 @@
+# Isolated Wine + capture environment for reverse-engineering the HP
+# proprietary Windows driver (issue #1019).
+#
+# Security note: this container uses its OWN network namespace (bridge,
+# no --network=host). All capture happens inside the container; nothing
+# on the host network or host certificate store is touched.
+#
+# Method: Wine's schannel is built on GnuTLS. A small LD_PRELOAD shim
+# (sslkeylog-gnutls.c) enables gnutls_session_set_keylog_function(), which
+# Wine never calls itself. Combined with tcpdump + tshark, the HTTPS traffic
+# of the Windows driver is decrypted in the clear.
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV WINEARCH=win64
+ENV WINEDEBUG=-all
+ENV PATH="/opt/wine-devel/bin:${PATH}"
+
+# WineHQ repository. Pin amd64/i386 to the SAME version: the bookworm repo
+# can temporarily have a newer amd64 than i386 (breaks the dependency).
+RUN dpkg --add-architecture i386 \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends wget gnupg ca-certificates \
+    && mkdir -p /etc/apt/keyrings \
+    && wget -qO- https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor -o /etc/apt/keyrings/winehq.gpg \
+    && echo "deb [arch=amd64,i386 signed-by=/etc/apt/keyrings/winehq.gpg] https://dl.winehq.org/wine-builds/debian/ bookworm main" > /etc/apt/sources.list.d/winehq.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+         wine-devel=11.10~bookworm-1 \
+         wine-devel-i386=11.10~bookworm-1 \
+         wine-devel-amd64=11.10~bookworm-1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Tools: Xvfb (headless GUI), tcpdump/tshark (capture + decrypt),
+# gcc + libgnutls (build the keylog shim), mono (Wine Mono for .NET-based
+# installers), OCR + UI driving (tesseract, imagemagick, xdotool), misc.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        xvfb \
+        tcpdump \
+        tshark \
+        gcc libgnutls28-dev \
+        mono-devel mono-utils \
+        winbind \
+        ca-certificates \
+        curl wget unzip cabextract xz-utils \
+        procps net-tools iproute2 iputils-ping \
+        xdotool x11-apps \
+        tesseract-ocr imagemagick \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /capture
+VOLUME /capture

--- a/protocol_doc/capture/tools/capture-https-windows.ps1
+++ b/protocol_doc/capture/tools/capture-https-windows.ps1
@@ -1,0 +1,622 @@
+[CmdletBinding(DefaultParameterSetName = "Setup")]
+param(
+    [Parameter(ParameterSetName = "Setup", Mandatory = $true)]
+    [string]$PrinterIP,
+
+    [Parameter(ParameterSetName = "Setup")]
+    [switch]$IpRedirect,
+
+    [Parameter(ParameterSetName = "Setup")]
+    [string]$PrinterIPv6,
+
+    [Parameter(ParameterSetName = "Setup")]
+    [int]$ListenPort = 8443,
+
+    [Parameter(ParameterSetName = "Setup")]
+    [ValidateSet("https", "http")]
+    [string]$ForwardScheme = "https",
+
+    [Parameter(ParameterSetName = "Setup")]
+    [Parameter(ParameterSetName = "Restore")]
+    [string]$ConfigIni,
+
+    [Parameter(ParameterSetName = "Setup")]
+    [string]$MitmwebPath,
+
+    [Parameter(ParameterSetName = "Setup")]
+    [int]$WebPort = 8081,
+
+    [Parameter(ParameterSetName = "Setup")]
+    [int]$WebPortHttp = 8082,
+
+    [Parameter(ParameterSetName = "Setup")]
+    [int]$HttpProxyPort = 8444,
+
+    [Parameter(ParameterSetName = "Setup")]
+    [string]$SaveFlows,
+
+    [Parameter(ParameterSetName = "Restore")]
+    [switch]$Restore,
+
+    [Parameter()]
+    [switch]$SkipElevate
+)
+
+$ErrorActionPreference = "Stop"
+$progressPreference = "SilentlyContinue"
+
+function Write-Step { param([string]$m) [Console]::Out.WriteLine("==> $m") }
+function Write-Ok { param([string]$m) [Console]::Out.WriteLine("    OK  $m") }
+function Write-Warn { param([string]$m) [Console]::Out.WriteLine("    WARN $m") }
+
+function Test-Admin {
+    $id = [Security.Principal.WindowsIdentity]::GetCurrent()
+    (New-Object Security.Principal.WindowsPrincipal($id)).IsInRole(
+        [Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Find-Mitmweb {
+    param([string]$Explicit)
+    if ($Explicit) {
+        if (-not (Test-Path -LiteralPath $Explicit)) { throw "MitmwebPath not found: $Explicit" }
+        return (Resolve-Path -LiteralPath $Explicit).Path
+    }
+    $c = Get-Command mitmweb.exe -ErrorAction SilentlyContinue
+    if ($c) { return $c.Source }
+    $candidates = @(
+        "$env:ProgramFiles\mitmproxy\bin\mitmweb.exe",
+        "${env:ProgramFiles(x86)}\mitmproxy\bin\mitmweb.exe",
+        "$env:LOCALAPPDATA\Programs\Python\Python31*\Scripts\mitmweb.exe",
+        "$env:LOCALAPPDATA\Programs\Python\Python39*\Scripts\mitmweb.exe",
+        "$env:LOCALAPPDATA\Programs\Python\Python*\Scripts\mitmweb.exe",
+        "$env:APPDATA\Python\Python*\Scripts\mitmweb.exe"
+    )
+    foreach ($c in $candidates) {
+        $g = Get-ChildItem -Path $c -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($g) { return $g.FullName }
+    }
+    $py = Get-Command python.exe -ErrorAction SilentlyContinue
+    if ($py) {
+        $s = Join-Path (Split-Path $py.Source) "Scripts\mitmweb.exe"
+        if (Test-Path -LiteralPath $s) { return $s }
+    }
+    throw "mitmweb.exe not found. Install mitmproxy (https://www.mitmproxy.org) or pass -MitmwebPath."
+}
+
+function Find-HpIni {
+    param([string]$Explicit, [string]$PrinterIP)
+    if ($Explicit) {
+        if (-not (Test-Path -LiteralPath $Explicit)) { throw "ConfigIni not found: $Explicit" }
+        return (Resolve-Path -LiteralPath $Explicit).Path
+    }
+    $roots = @("$env:ProgramData\HP", "$env:ProgramFiles\HP")
+    $all = @()
+    foreach ($r in $roots) {
+        if (Test-Path -LiteralPath $r) {
+            $all += Get-ChildItem -LiteralPath $r -Recurse -Filter *.ini -ErrorAction SilentlyContinue |
+                Where-Object { $_.FullName -match "NetworkDevices" } |
+                Select-Object -ExpandProperty FullName
+        }
+    }
+    $all = @($all | Select-Object -Unique)
+    if ($all.Count -eq 0) {
+        throw "No NetworkDevices\*.ini found under ProgramData\HP or Program Files\HP. Pass -ConfigIni <path>."
+    }
+    if ($all.Count -eq 1) { return $all[0] }
+    $matchIP = @($all | Where-Object {
+        try { (Get-Content -LiteralPath $_ -Raw -ErrorAction Stop) -match [regex]::Escape($PrinterIP) } catch { $false }
+    })
+    if ($matchIP.Count -ge 1) {
+        if ($matchIP.Count -eq 1) { return $matchIP[0] }
+        Write-Warn "Several NetworkDevices ini reference $PrinterIP; using the first."
+        return $matchIP[0]
+    }
+    return $all[0]
+}
+
+function Read-IniText {
+    param([string]$Path, [ref]$Encoding)
+    $bytes = [System.IO.File]::ReadAllBytes($Path)
+    if ($bytes.Length -ge 2 -and $bytes[0] -eq 0xFF -and $bytes[1] -eq 0xFE) {
+        $Encoding.Value = "Unicode"
+        return [System.Text.Encoding]::Unicode.GetString($bytes)
+    }
+    if ($bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) {
+        $Encoding.Value = "UTF8"
+        return [System.Text.Encoding]::UTF8.GetString($bytes)
+    }
+    $Encoding.Value = "Default"
+    return [System.Text.Encoding]::Default.GetString($bytes)
+}
+
+function Write-IniText {
+    param([string]$Path, [string]$Text, [string]$Encoding)
+    switch ($Encoding) {
+        "Unicode" {
+            $data = [System.Text.Encoding]::Unicode.GetPreamble() + [System.Text.Encoding]::Unicode.GetBytes($Text)
+        }
+        "UTF8" {
+            $data = [System.Text.Encoding]::UTF8.GetPreamble() + [System.Text.Encoding]::UTF8.GetBytes($Text)
+        }
+        default {
+            $data = [System.Text.Encoding]::Default.GetBytes($Text)
+        }
+    }
+    [System.IO.File]::WriteAllBytes($Path, $data)
+}
+
+function Get-HpTempDir {
+    return (Join-Path $env:TEMP "hp-mitm-capture")
+}
+
+function Get-BackupDir {
+    return (Join-Path (Get-HpTempDir) "backups")
+}
+
+function Get-SessionStateFile {
+    $dir = Get-HpTempDir
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    return (Join-Path $dir "session-state.txt")
+}
+
+function Write-SessionState {
+    param([hashtable]$Data)
+    $lines = $Data.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" }
+    Set-Content -LiteralPath (Get-SessionStateFile) -Value $lines -Encoding ASCII
+}
+
+function Read-SessionState {
+    $f = Get-SessionStateFile
+    $h = @{}
+    if (Test-Path -LiteralPath $f) {
+        Get-Content -LiteralPath $f -ErrorAction SilentlyContinue | ForEach-Object {
+            if ($_ -match "^(.*?)=(.*)$") { $h[$Matches[1]] = $Matches[2] }
+        }
+    }
+    return $h
+}
+
+function Backup-Ini {
+    param([string]$Ini)
+    $stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $base = [System.IO.Path]::GetFileNameWithoutExtension($Ini)
+    $dir = Get-BackupDir
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    $target = Join-Path $dir "ini-$base-$stamp.ini"
+    Copy-Item -LiteralPath $Ini -Destination $target -Force
+    Write-Ok "backed up driver ini to $target"
+    return $target
+}
+
+function Get-SessionIniPtr {
+    $dir = Get-BackupDir
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    return (Join-Path $dir "session-ini.txt")
+}
+
+function Find-LatestBackup {
+    param([string]$Ini)
+    $base = [System.IO.Path]::GetFileNameWithoutExtension($Ini)
+    $dir = Get-BackupDir
+    if (-not (Test-Path -LiteralPath $dir)) { return $null }
+    $cands = Get-ChildItem -LiteralPath $dir -Filter "ini-$base-*.ini" -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime -Descending
+    if ($cands.Count -eq 0) { return $null }
+    $pristine = @($cands | Where-Object {
+        try { -not ((Get-Content -LiteralPath $_.FullName -Raw -ErrorAction Stop) -match "IPAddress\s*=\s*127\.0\.0\.1") } catch { $true }
+    })
+    if ($pristine.Count -gt 0) { return $pristine[0].FullName }
+    return $cands[0].FullName
+}
+
+function Remove-MitmproxyCAPaths {
+    foreach ($store in @("Cert:\LocalMachine\Root", "Cert:\CurrentUser\Root")) {
+        $certs = Get-ChildItem $store -ErrorAction SilentlyContinue |
+            Where-Object { $_.Subject -like "*mitmproxy*" }
+        foreach ($cert in $certs) {
+            try {
+                Remove-Item -LiteralPath ($store + "\" + $cert.Thumbprint) -ErrorAction Stop
+                Write-Ok "removed CA $($cert.Subject) from $store"
+            } catch {
+                Write-Warn "could not remove CA from $store : $_"
+            }
+        }
+    }
+}
+
+function Teardown-IpRedirect {
+    param([string]$Ip, [int]$HttpPort)
+    $route = Get-NetRoute -DestinationPrefix "$Ip/32" -ErrorAction SilentlyContinue
+    if ($route) {
+        Remove-NetRoute -DestinationPrefix "$Ip/32" -InterfaceIndex $route[0].ifIndex -Confirm:$false -ErrorAction SilentlyContinue | Out-Null
+        Write-Ok "removed route $Ip/32"
+    }
+    $addr = Get-NetIPAddress -IPAddress $Ip -ErrorAction SilentlyContinue
+    if ($addr) {
+        Remove-NetIPAddress -IPAddress $Ip -InterfaceIndex $addr[0].InterfaceIndex -Confirm:$false -ErrorAction SilentlyContinue | Out-Null
+        Write-Ok "removed local address $Ip"
+    }
+    netsh interface portproxy delete v4tov4 listenaddress=$Ip listenport=80 2>$null | Out-Null
+    Write-Ok "removed portproxy $Ip:80 -> 127.0.0.1:$HttpPort"
+}
+
+function Start-Mitmweb {
+    param([string]$Exe, [string[]]$ProcArgs, [string]$Tag)
+    $dir = Get-HpTempDir
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    $errFile = Join-Path $dir "mitmweb-$Tag-stderr.txt"
+    $outFile = Join-Path $dir "mitmweb-$Tag-stdout.txt"
+    $p = Start-Process -FilePath $Exe -ArgumentList $ProcArgs -WindowStyle Hidden `
+        -RedirectStandardOutput $outFile -RedirectStandardError $errFile -PassThru
+    Start-Sleep -Seconds 2
+    if ($p.HasExited) {
+        $detail = ""
+        if (Test-Path -LiteralPath $errFile) {
+            $lines = @(Get-Content -LiteralPath $errFile -ErrorAction SilentlyContinue | Select-Object -Last 4)
+            if ($lines.Count) { $detail = "`n" + ($lines -join "`n") }
+        }
+        throw "mitmweb ($Tag) exited immediately. Is the port in use? $detail"
+    }
+    return $p
+}
+
+function Ensure-CA {
+    param([string]$Mitmweb)
+    $caPem = Join-Path (Join-Path $HOME ".mitmproxy") "mitmproxy-ca-cert.pem"
+    if (-not (Test-Path -LiteralPath $caPem)) {
+        Write-Step "Generating the mitmproxy CA (first run)..."
+        $probe = Start-Process -FilePath $Mitmweb -ArgumentList @(
+            "--listen-host", "127.0.0.1", "--listen-port", "9123",
+            "--no-web-open-browser", "--set", "web_password=init"
+        ) -WindowStyle Hidden -PassThru `
+            -RedirectStandardOutput (Join-Path (Get-HpTempDir) "mitmweb-cagen-stdout.txt") `
+            -RedirectStandardError (Join-Path (Get-HpTempDir) "mitmweb-cagen-stderr.txt")
+        $deadline = (Get-Date).AddSeconds(15)
+        while ((Get-Date) -lt $deadline -and -not (Test-Path -LiteralPath $caPem)) { Start-Sleep -Milliseconds 300 }
+        Stop-Process -Id $probe.Id -Force -ErrorAction SilentlyContinue
+    }
+    if (-not (Test-Path -LiteralPath $caPem)) {
+        throw "mitmproxy CA was not generated at $caPem."
+    }
+    Write-Ok "mitmproxy CA ready: $caPem"
+    return $caPem
+}
+
+function Import-CA-IntoStore {
+    param([string]$CaPem)
+    Write-Step "Importing the mitmproxy CA into the Windows root store"
+    $imported = $false
+    try {
+        Import-Certificate -FilePath $CaPem -CertStoreLocation Cert:\LocalMachine\Root -ErrorAction Stop | Out-Null
+        Write-Ok "installed into Cert:\LocalMachine\Root"
+        $imported = $true
+    } catch {
+        Write-Warn "LocalMachine\Root import failed: $_"
+    }
+    if (-not $imported) {
+        try {
+            Import-Certificate -FilePath $CaPem -CertStoreLocation Cert:\CurrentUser\Root -ErrorAction Stop | Out-Null
+            Write-Ok "installed into Cert:\CurrentUser\Root"
+            $imported = $true
+        } catch {
+            throw "Could not import the mitmproxy CA into any root store: $_"
+        }
+    }
+}
+
+function Write-SessionReadme {
+    param([string]$Dir, [string[]]$Lines)
+    New-Item -ItemType Directory -Force -Path $Dir | Out-Null
+    $readme = Join-Path $Dir "README.txt"
+    Set-Content -LiteralPath $readme -Value $Lines -Encoding Default
+    Write-Ok "session info written to $readme"
+}
+
+if (-not $SkipElevate -and -not (Test-Admin)) {
+    Write-Step "Requesting administrator rights (UAC)..."
+    $parts = @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "`"$PSCommandPath`"")
+    foreach ($k in $PSBoundParameters.Keys) {
+        $v = $PSBoundParameters[$k]
+        if ($v -is [switch]) {
+            if ($v) { $parts += "-$k" }
+        } else {
+            $parts += "-$k"
+            $parts += "`"$v`""
+        }
+    }
+    $logDir = Get-HpTempDir
+    New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+    $log = Join-Path $logDir "setup-log.txt"
+    $logErr = $log + ".err"
+    $p = $null
+    try {
+        $p = Start-Process -FilePath "powershell.exe" -ArgumentList $parts -Verb RunAs -Wait -PassThru `
+            -RedirectStandardOutput $log -RedirectStandardError $logErr
+    } catch {
+        Write-Warn "Elevation was refused or failed. Re-run this script from an elevated PowerShell (Run as administrator)."
+        exit 0
+    }
+    [Console]::Out.WriteLine("")
+    if (Test-Path -LiteralPath $log) {
+        Get-Content -LiteralPath $log | ForEach-Object { [Console]::Out.WriteLine($_) }
+    }
+    if (Test-Path -LiteralPath $logErr) {
+        [Console]::Out.WriteLine("-- errors --")
+        Get-Content -LiteralPath $logErr | ForEach-Object { [Console]::Out.WriteLine($_) }
+    }
+    exit $p.ExitCode
+}
+
+$stale = @(Get-Process mitmweb -ErrorAction SilentlyContinue)
+if ($stale.Count -gt 0) {
+    Write-Warn "stopping stale mitmweb from a previous session (PID $($stale.Id -join ', '))"
+    $stale | Stop-Process -Force
+    Start-Sleep -Milliseconds 500
+}
+
+if ($Restore) {
+    Write-Step "Restore mode"
+    $state = Read-SessionState
+    $ini = $null
+    if ($state["Mode"] -eq "IpRedirect") {
+        Teardown-IpRedirect -Ip $state["PrinterIP"] -HttpPort ([int]$state["HttpPort"])
+    } else {
+        if ($ConfigIni) {
+            if (Test-Path -LiteralPath $ConfigIni) { $ini = (Resolve-Path -LiteralPath $ConfigIni).Path }
+        }
+        if (-not $ini) {
+            $ptr = Get-SessionIniPtr
+            if (Test-Path -LiteralPath $ptr) {
+                $ini = Get-Content -LiteralPath $ptr -ErrorAction SilentlyContinue |
+                    Where-Object { $_ -and (Test-Path -LiteralPath $_) } |
+                    Select-Object -First 1
+            }
+        }
+        if (-not $ini) {
+            Write-Warn "No HP driver ini known for restore. Re-run with -Restore -ConfigIni <path>."
+        } else {
+            $backup = Find-LatestBackup -Ini $ini
+            if (-not $backup) {
+                Write-Warn "No backup found for $ini in $(Get-BackupDir). Nothing to restore."
+            } else {
+                Copy-Item -LiteralPath $backup -Destination $ini -Force
+                Write-Ok "restored $ini from $backup"
+            }
+        }
+    }
+    if (-not $ini) {
+        try { $ini = Find-HpIni -Explicit "" -PrinterIP "127.0.0.1" } catch { $ini = $null }
+    }
+    if ($ini -and (Test-Path -LiteralPath $ini)) {
+        $enc = "Default"
+        $txt = Read-IniText -Path $ini -Encoding ([ref]$enc)
+        if ($txt -match "(?im)^[ \t]*IPAddress[ \t]*=\s*127\.0\.0\.1") {
+            $pb = Find-LatestBackup -Ini $ini
+            if ($pb) {
+                Copy-Item -LiteralPath $pb -Destination $ini -Force
+                Write-Ok "repaired $ini (was pointed to 127.0.0.1) from $pb"
+            } else {
+                Write-Warn "$ini points to 127.0.0.1 but no pristine backup found; edit it manually."
+            }
+        }
+    }
+    Remove-MitmproxyCAPaths
+    Get-Process mitmweb -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+    Write-Step "Done. Restart the HP application so it re-reads the printer IP, then re-run discovery."
+    exit 0
+}
+
+if (-not ($PrinterIP -as [System.Net.IPAddress])) {
+    throw "PrinterIP '$PrinterIP' is not a valid IPv4 address."
+}
+$mitmweb = Find-Mitmweb -Explicit $MitmwebPath
+Write-Ok "mitmweb: $mitmweb"
+
+$ini = Find-HpIni -Explicit $ConfigIni -PrinterIP $PrinterIP
+if ($ini -notlike "*\*.ini") {
+    throw "Find-HpIni returned an invalid path: '$ini'"
+}
+Write-Ok "driver config: $ini"
+
+$enc = "Default"
+$text = Read-IniText -Path $ini -Encoding ([ref]$enc)
+if ($text -match "(?im)^[ \t]*IPAddress[ \t]*=\s*(\S+)") {
+    $iniIP = $Matches[1]
+} else {
+    $iniIP = $null
+}
+if ($text -match "(?im)^[ \t]*PortNumber[ \t]*=\s*(\d+)") {
+    $iniPort = [int]$Matches[1]
+} else {
+    $iniPort = $null
+}
+if ($text -match "(?im)^[ \t]*IPv6Address[ \t]*=\s*(\S+)") {
+    $iniV6 = $Matches[1]
+} else {
+    $iniV6 = $null
+}
+Write-Ok "ini says IPAddress=$iniIP PortNumber=$iniPort IPv6Address=$iniV6"
+
+if ($IpRedirect) {
+    Write-Step "Mode: IP redirection (intercept 192.168.129.X on this machine, forward via IPv6 link-local)"
+    if (-not $PrinterIPv6) {
+        if (-not $iniV6) {
+            throw "-IpRedirect needs the printer IPv6 link-local: auto-read from the ini failed. Pass -PrinterIPv6 fe80::..."
+        }
+        $PrinterIPv6 = $iniV6
+    }
+    $upstream = "https://[$PrinterIPv6]"
+    $upstreamHttp = "http://[$PrinterIPv6]"
+
+    $loop = @(Get-NetIPInterface -ErrorAction SilentlyContinue |
+        Where-Object { $_.InterfaceAlias -like "*loopback*" -or $_.InterfaceDescription -like "*loopback*" })
+    if ($loop.Count -eq 0) {
+        $loop = @(Get-NetIPInterface -ErrorAction SilentlyContinue | Where-Object { $_.InterfaceIndex -eq 1 })
+    }
+    if ($loop.Count -lt 1) { throw "Loopback adapter not found." }
+    $loopIdx = $loop[0].InterfaceIndex
+
+    Write-Step "Hijacking $PrinterIP to the loopback interface (ifIndex $loopIdx)"
+    $existingIp = Get-NetIPAddress -IPAddress $PrinterIP -ErrorAction SilentlyContinue
+    if ($existingIp) {
+        Write-Warn "$PrinterIP already assigned locally; removing it first (previous session not restored?)"
+        Remove-NetIPAddress -IPAddress $PrinterIP -InterfaceIndex $existingIp[0].InterfaceIndex -Confirm:$false -ErrorAction SilentlyContinue | Out-Null
+    }
+    Get-NetRoute -DestinationPrefix "$PrinterIP/32" -ErrorAction SilentlyContinue |
+        Remove-NetRoute -Confirm:$false -ErrorAction SilentlyContinue | Out-Null
+    netsh interface portproxy delete v4tov4 listenaddress=$PrinterIP listenport=443 2>$null | Out-Null
+    netsh interface portproxy delete v4tov4 listenaddress=$PrinterIP listenport=80 2>$null | Out-Null
+    New-NetIPAddress -InterfaceIndex $loopIdx -IPAddress $PrinterIP -PrefixLength 32 | Out-Null
+    New-NetRoute -InterfaceIndex $loopIdx -DestinationPrefix "$PrinterIP/32" -ErrorAction SilentlyContinue | Out-Null
+    Write-Ok "$PrinterIP now routes to localhost"
+
+    $tokenH = -join ((48..57) + (97..122) | Get-Random -Count 12 | ForEach-Object { [char]$_ })
+    $tokenW = -join ((48..57) + (97..122) | Get-Random -Count 12 | ForEach-Object { [char]$_ })
+
+    Write-Step "Starting mitmweb reverse proxy (HTTPS $PrinterIP:443 -> $upstream)"
+    $argsH = @(
+        "--listen-host", $PrinterIP, "--listen-port", "443",
+        "--mode", "reverse:$upstream",
+        "--ssl-insecure", "--no-web-open-browser",
+        "--set", "connection_strategy=lazy",
+        "--set", "web_password=$tokenH",
+        "--set", "web_port=$WebPort"
+    )
+    $p443 = Start-Mitmweb -Exe $mitmweb -ProcArgs $argsH -Tag "https-443"
+
+    Write-Step "Starting mitmweb reverse proxy (HTTP $PrinterIP:80 via portproxy -> 127.0.0.1:$HttpProxyPort -> $upstreamHttp)"
+    $argsW = @(
+        "--listen-host", "127.0.0.1", "--listen-port", "$HttpProxyPort",
+        "--mode", "reverse:$upstreamHttp",
+        "--ssl-insecure", "--no-web-open-browser",
+        "--set", "connection_strategy=lazy",
+        "--set", "web_password=$tokenW",
+        "--set", "web_port=$WebPortHttp"
+    )
+    $p8444 = Start-Mitmweb -Exe $mitmweb -ProcArgs $argsW -Tag "http-8444"
+    netsh interface portproxy add v4tov4 listenaddress=$PrinterIP listenport=80 connectaddress=127.0.0.1 connectport=$HttpProxyPort | Out-Null
+    Write-Ok "portproxy $PrinterIP:80 -> 127.0.0.1:$HttpProxyPort"
+
+    $caPem = Ensure-CA -Mitmweb $mitmweb
+    Import-CA-IntoStore -CaPem $caPem
+
+    Write-SessionState @{
+        Mode = "IpRedirect"
+        PrinterIP = $PrinterIP
+        PrinterIPv6 = $PrinterIPv6
+        HttpPort = $HttpProxyPort
+        Pid443 = $p443.Id
+        Pid8444 = $p8444.Id
+    }
+    Write-SessionReadme -Dir (Join-Path $PWD "hp-mitm-capture") -Lines @(
+        "mitmproxy IP-redirect capture session - $(Get-Date -Format s)",
+        "Printer   : $PrinterIP (intercepted on this machine)",
+        "Upstream  : $upstream  /  $upstreamHttp",
+        "HTTPS UI  : http://127.0.0.1:$WebPort  (token: $tokenH)",
+        "HTTP  UI  : http://127.0.0.1:$WebPortHttp  (token: $tokenW)",
+        "PIDs      : $($p443.Id), $($p8444.Id)",
+        "Ini       : $ini"
+    )
+
+    Write-Step "Capture is armed (IP redirection). Next steps:"
+    [Console]::Out.WriteLine("  1. Keep this machine on the LAN. Only outbound connections to $PrinterIP are intercepted; the printer itself is untouched.")
+    [Console]::Out.WriteLine("  2. Restart the HP application (ScanToPCActivationApp / HP Scan).")
+    [Console]::Out.WriteLine("  3. HTTPS events: open http://127.0.0.1:$WebPort, token $tokenH")
+    [Console]::Out.WriteLine("  4. HTTP events:   open http://127.0.0.1:$WebPortHttp, token $tokenW")
+    [Console]::Out.WriteLine("  5. Trigger the scan / device events from the printer panel.")
+    [Console]::Out.WriteLine("  6. When done: $PSCommandPath -Restore")
+} else {
+    Write-Step "Mode: ini redirect (point the driver at a local reverse proxy)"
+
+    if ($PrinterIP -notin @("127.0.0.1", "localhost")) {
+        $reachable = Test-NetConnection -ComputerName $PrinterIP -Port 443 -InformationLevel Quiet -WarningAction SilentlyContinue
+        if ($reachable) {
+            Write-Ok "printer reachable on TCP 443 (HTTPS)"
+        } else {
+            Write-Warn "printer is not reachable on TCP 443; it may only speak plain HTTP on ports 80/8080. Use -ForwardScheme http if needed."
+        }
+    }
+
+    Set-Content -LiteralPath (Get-SessionIniPtr) -Value $ini -Encoding ASCII
+
+    $alreadyRedirected = ($iniIP -and $iniIP -eq "127.0.0.1")
+    if ($alreadyRedirected) {
+        Write-Warn "the driver ini already points to 127.0.0.1 (previous capture not restored?)"
+        Write-Warn "not taking a new backup (it would not be pristine); run -Restore to put the printer IP back"
+    }
+    if ($iniPort) {
+        if ($ForwardScheme -eq "https" -and $iniPort -notin @("443", "8443")) {
+            Write-Warn "ini PortNumber=$iniPort suggests plain HTTP; if the scan fails, re-run with -ForwardScheme http"
+        }
+        if ($ForwardScheme -eq "http" -and $iniPort -eq "443") {
+            Write-Warn "ini PortNumber=443 suggests HTTPS; if the scan fails, re-run with -ForwardScheme https"
+        }
+    }
+
+    if ($alreadyRedirected) {
+        $backup = Find-LatestBackup -Ini $ini
+        if (-not $backup) { $backup = "<none>" }
+    } else {
+        $backup = Backup-Ini -Ini $ini
+    }
+    $hasIp = ($text -match "(?im)^[ \t]*IPAddress[ \t]*=.*$")
+    $hasPort = ($text -match "(?im)^[ \t]*PortNumber[ \t]*=.*$")
+    $newText = $text -replace "(?im)^[ \t]*IPAddress[ \t]*=.*$", "IPAddress=127.0.0.1"
+    $newText = $newText -replace "(?im)^[ \t]*PortNumber[ \t]*=.*$", "PortNumber=$ListenPort"
+    if (-not ($hasIp -or $hasPort)) {
+        Write-Warn "neither IPAddress= nor PortNumber= found in the ini; leaving the file untouched (edit it manually or pass -ConfigIni)."
+    } else {
+        Write-IniText -Path $ini -Text $newText -Encoding $enc
+        Write-Ok "driver now points to 127.0.0.1:$ListenPort"
+    }
+
+    $webToken = -join ((48..57) + (97..122) | Get-Random -Count 12 | ForEach-Object { [char]$_ })
+    $webPortArgs = @()
+    if ($WebPort -gt 0) { $webPortArgs += "--set"; $webPortArgs += "web_port=$WebPort" }
+    $flowArgs = @()
+    if ($SaveFlows) { $flowArgs = @("--save-stream-file", $SaveFlows) }
+
+    $target = "reverse:$ForwardScheme" + "://" + $PrinterIP
+    $procArgs = @(
+        "--listen-host", "127.0.0.1",
+        "--listen-port", "$ListenPort",
+        "--mode", $target,
+        "--ssl-insecure",
+        "--no-web-open-browser",
+        "--set", "connection_strategy=lazy",
+        "--set", "web_password=$webToken"
+    ) + $webPortArgs + $flowArgs
+
+    Write-Step "Starting mitmweb reverse proxy (127.0.0.1:$ListenPort -> $target)"
+    $p = Start-Mitmweb -Exe $mitmweb -ProcArgs $procArgs -Tag "ini"
+    Write-Ok "mitmweb running (PID $($p.Id))"
+
+    $caPem = Ensure-CA -Mitmweb $mitmweb
+    Import-CA-IntoStore -CaPem $caPem
+
+    Write-SessionState @{
+        Mode = "IniRedirect"
+        PrinterIP = $PrinterIP
+        Port = $ListenPort
+        BackedUpIni = $backup
+        Ini = $ini
+    }
+    Write-SessionReadme -Dir (Join-Path $PWD "hp-mitm-capture") -Lines @(
+        "mitmproxy ini-redirect capture session - $(Get-Date -Format s)",
+        "Printer  : $PrinterIP",
+        "Proxy    : 127.0.0.1:$ListenPort",
+        "Mode     : $target",
+        "mitmweb  : http://127.0.0.1:$WebPort  (ui token: $webToken)",
+        "PID      : $($p.Id)",
+        "Backup   : $backup",
+        "Ini      : $ini"
+    )
+
+    Write-Step "Capture is armed (ini redirect). Next steps:"
+    [Console]::Out.WriteLine("  1. Close and restart the HP scan application (ScanToPCActivationApp / HP Scan).")
+    [Console]::Out.WriteLine("  2. The driver will talk to 127.0.0.1:$ListenPort instead of the real printer.")
+    [Console]::Out.WriteLine("  3. Open the mitmweb UI at http://127.0.0.1:$WebPort and enter the token: $webToken")
+    [Console]::Out.WriteLine("  4. Trigger a scan from the printer panel.")
+    [Console]::Out.WriteLine("  5. When done, restore the driver with:")
+    [Console]::Out.WriteLine("     powershell -ExecutionPolicy Bypass -File `"$PSCommandPath`" -Restore")
+}

--- a/protocol_doc/capture/tools/drive-installer.sh
+++ b/protocol_doc/capture/tools/drive-installer.sh
@@ -1,0 +1,206 @@
+#!/bin/bash
+# drive-installer.sh — drive the interactive HP webpack installer under Wine.
+#
+# The HP driver "webpack" (Full_Webpack-*.exe) extracts and runs an
+# interactive installer (hp-dqex5.exe) whose screens are rendered by a
+# WebView control. This script launches it in the isolated container and
+# drives the screens by OCR (tesseract) + clicks (xdotool):
+#   - "Let's get started"                      -> click "Continue"
+#   - "Installation Agreements and Settings"   -> check "I have reviewed and
+#     accept..." then click "Accept"
+#
+# All X11 operations run INSIDE the container (its Xvfb :99 display).
+#
+# Usage:
+#   drive-installer.sh <webpack-exe> [container]
+#
+# Examples:
+#   drive-installer.sh "/downloads/Full_Webpack-50.2.4593_1-ST570_Full_Webpack.exe"
+#   drive-installer.sh "/path/to/webpack.exe" wine-capture-test
+set -euo pipefail
+
+WEBPACK="${1:?usage: drive-installer.sh <webpack-exe> [container]}"
+C="${2:-wine-capture-test}"
+
+# Run a shell snippet inside the container (X11 tools live there).
+xsh() { docker exec "$C" bash -c "$1"; }
+
+# --- helpers --------------------------------------------------------------
+
+# Wait for a visible window whose name matches a regex; echo the window id.
+wait_window() {
+  local name_re="$1" tries="${2:-90}"
+  for _ in $(seq 1 "$tries"); do
+    # xdotool may return stale ids; accept only ids that resolve to a
+    # live window with the expected name.
+    local id
+    id=$(xsh "timeout 3 env DISPLAY=:99 xdotool search --onlyvisible --name '$name_re' 2>/dev/null | head -1" || true)
+    if [ -n "$id" ]; then
+      local ok
+      ok=$(xsh "timeout 3 env DISPLAY=:99 xdotool getwindowname $id 2>/dev/null" || true)
+      if [ -n "$ok" ]; then
+        echo "$id"
+        return 0
+      fi
+    fi
+    sleep 1
+  done
+  echo "error: window '$name_re' not found" >&2
+  return 1
+}
+
+# Screenshot a window id to a png (inside the container).
+shot() {
+  local id="$1" out="$2"
+  xsh "timeout 5 env DISPLAY=:99 import -window $id $out 2>/dev/null \
+       || timeout 5 env DISPLAY=:99 xwd -id $id 2>/dev/null | convert xwd:- $out 2>/dev/null \
+       || exit 1"
+}
+
+# Find the window-relative coordinates of a text word via tesseract TSV.
+# With pick=last it returns the bottom-most occurrence (e.g. the real
+# "Accept" button rather than an earlier label). Echoes "X Y".
+find_text() {
+  local png="$1" word="$2" scale="${3:-2}" pick="${4:-first}"
+  local big="/tmp/find_text_$$.png"
+  xsh "convert $png -colorspace gray -resize ${scale}00% -sharpen 0x1 $big 2>/dev/null
+       tesseract $big stdout --psm 11 tsv 2>/dev/null \
+         | awk -F'\t' -v w='$word' 'tolower(\$12)==tolower(w) { print }' \
+         | { if [ '$pick' = 'last' ]; then tail -1; else head -1; fi }" >/tmp/ocr_line.$$ 
+  local line; line=$(cat /tmp/ocr_line.$$); rm -f /tmp/ocr_line.$$
+  if [ -z "$line" ]; then
+    xsh "rm -f $big"
+    return 1
+  fi
+  local left top width height
+  left=$(echo "$line" | cut -f7)
+  top=$(echo "$line" | cut -f8)
+  width=$(echo "$line" | cut -f9)
+  height=$(echo "$line" | cut -f10)
+  local x y
+  x=$(( (left + width / 2) / scale ))
+  y=$(( (top + height / 2) / scale ))
+  xsh "rm -f $big"
+  echo "$x $y"
+}
+
+# Click at an absolute screen coordinate (inside the container).
+click() {
+  local x="$1" y="$2"
+  xsh "timeout 3 env DISPLAY=:99 xdotool mousemove $x $y click 1 2>/dev/null || exit 1"
+  sleep 1
+}
+
+# Re-discover the live window id matching the installer name (ids change
+# between runs / screens).
+find_installer_window() {
+  local id
+  id=$(xsh "timeout 3 env DISPLAY=:99 xdotool search --onlyvisible --name 'HP Smart Tank Plus 570 series' 2>/dev/null | while read w; do n=\$(timeout 2 env DISPLAY=:99 xdotool getwindowname \$w 2>/dev/null || true); [ -n \"\$n\" ] && echo \$w && break; done" || true)
+  echo "$id"
+}
+
+# Click on a word found by OCR, retrying for a while.
+click_word() {
+  local id="$1" word="$2" tries="${3:-20}"
+  local png="/tmp/shot_$$.png"
+  for _ in $(seq 1 "$tries"); do
+    local live
+    live=$(find_installer_window)
+    if [ -n "$live" ] && shot "$live" "$png" 2>/dev/null; then
+      local pos
+      # pick=last: click the bottom-most occurrence (the real button, not an
+      # earlier label in the EULA text).
+      if pos=$(find_text "$png" "$word" 2 last); then
+        local win_x win_y
+        read -r win_x win_y <<<"$pos"
+        local ax ay
+        ax=$(xsh "timeout 3 env DISPLAY=:99 xdotool getwindowgeometry $live 2>/dev/null | awk '/Position:/{print \$2}' | cut -d, -f1" || true)
+        ay=$(xsh "timeout 3 env DISPLAY=:99 xdotool getwindowgeometry $live 2>/dev/null | awk '/Position:/{print \$2}' | cut -d, -f2" || true)
+        ax=${ax:-0}; ay=${ay:-0}
+        echo ">> clicking '$word' at ($((ax + win_x)), $((ay + win_y)))"
+        click $((ax + win_x)) $((ay + win_y))
+        return 0
+      fi
+    fi
+    sleep 1
+  done
+  echo "warn: word '$word' not found after $tries tries" >&2
+  return 1
+}
+
+# Check a WebView checkbox by clicking just left of a label word.
+check_box_before_word() {
+  local id="$1" label="$2" tries="${3:-20}"
+  local png="/tmp/shot_$$.png"
+  for _ in $(seq 1 "$tries"); do
+    local live
+    live=$(find_installer_window)
+    if [ -n "$live" ] && shot "$live" "$png" 2>/dev/null; then
+      local pos
+      # pick=first: the checkbox sits just left of the first label word.
+      if pos=$(find_text "$png" "$label" 2 first); then
+        local win_x win_y
+        read -r win_x win_y <<<"$pos"
+        local ax ay
+        ax=$(xsh "timeout 3 env DISPLAY=:99 xdotool getwindowgeometry $live 2>/dev/null | awk '/Position:/{print \$2}' | cut -d, -f1" || true)
+        ay=$(xsh "timeout 3 env DISPLAY=:99 xdotool getwindowgeometry $live 2>/dev/null | awk '/Position:/{print \$2}' | cut -d, -f2" || true)
+        ax=${ax:-0}; ay=${ay:-0}
+        for off in 20 30 40 55; do
+          local cx=$((ax + win_x - off)) cy=$((ay + win_y))
+          echo ">> trying checkbox at ($cx, $cy)"
+          click "$cx" "$cy"
+        done
+        return 0
+      fi
+    fi
+    sleep 1
+  done
+  echo "warn: label '$label' not found after $tries tries" >&2
+  return 1
+}
+
+# --- main -----------------------------------------------------------------
+
+echo "==> webpack: $WEBPACK"
+docker cp "$WEBPACK" "$C:/tmp/installer.exe" 2>/dev/null \
+  || { echo "error: cannot copy $WEBPACK into $C (does the container run?)" >&2; exit 1; }
+
+# clean any previous installer state so re-runs don't conflict
+# (exclude this shell's own PID, since pgrep -f matches its own cmdline)
+xsh 'SELF=$$
+for p in $(pgrep -f "HP-DQEX5" 2>/dev/null); do [ "$p" != "$SELF" ] && kill -9 $p 2>/dev/null || true; done
+for p in $(pgrep -f "installer[.]exe" 2>/dev/null); do [ "$p" != "$SELF" ] && kill -9 $p 2>/dev/null || true; done
+su -s /bin/bash wineuser -c "wineserver -k" 2>/dev/null || true
+sleep 3'
+
+# Xvfb + explorer (needed for Wine windows to render)
+xsh 'pgrep -a Xvfb >/dev/null || (Xvfb :99 -screen 0 1280x800x24 -ac >/tmp/xvfb.log 2>&1 & sleep 2)
+su -s /bin/bash wineuser -c "WINEDEBUG=-all explorer.exe /desktop" >/dev/null 2>&1 &' || true
+sleep 3
+
+# launch the webpack in the background (with the keylog shim if present)
+docker exec "$C" bash -c 'cd /tmp && DISPLAY=:99 su -s /bin/bash wineuser -c \
+  "export DISPLAY=:99; export SSLKEYLOGFILE=/capture/keys.log; \
+   export LD_PRELOAD=/opt/sslkeylog-gnutls.so; export WINEDEBUG=-all; \
+   wine installer.exe"' >/tmp/installer_run.log 2>&1 &
+echo "==> installer launched"
+
+# --- screen 1: "Let's get started" -> Continue ---------------------------
+echo "==> waiting for installer window..."
+WIN=$(wait_window "HP Smart Tank Plus 570 series" 90) || { cat /tmp/installer_run.log >&2; exit 1; }
+echo "==> installer window: $WIN"
+
+sleep 3
+click_word "$WIN" "Continue" 30 || echo "warn: could not click Continue"
+
+# --- screen 2: EULA -> check "I have reviewed..." -> Accept ---------------
+echo "==> waiting for EULA screen..."
+sleep 4
+check_box_before_word "$WIN" "have" 30 || true
+click_word "$WIN" "Accept" 30 || echo "warn: could not click Accept"
+click_word "$WIN" "Next" 20 || true
+
+echo
+echo "==> Installer driving done (as far as scripted)."
+echo "    Continue manually via VNC/X if further screens appear."
+echo "    Installer log: /tmp/installer_run.log"

--- a/protocol_doc/capture/tools/export-flows.py
+++ b/protocol_doc/capture/tools/export-flows.py
@@ -1,0 +1,43 @@
+from mitmproxy import http
+import os
+import re
+import time
+
+OUT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "exported")
+os.makedirs(OUT, exist_ok=True)
+LOG = open(os.path.join(OUT, "summary.txt"), "w", encoding="utf-8")
+SAFE = re.compile(r'[^A-Za-z0-9._-]+')
+
+
+def _safe(path):
+    return SAFE.sub("_", path).strip("_")
+
+
+def _write_body(flow: http.HTTPFlow, resp: http.Response):
+    if not resp.raw_content:
+        return
+    ctype = resp.headers.get("content-type", "")
+    if ctype.startswith("image"):
+        ext = "img"
+    elif "xml" in ctype:
+        ext = "xml"
+    elif "json" in ctype:
+        ext = "json"
+    elif ctype.startswith("text"):
+        ext = "text"
+    else:
+        ext = "bin"
+    ts = time.strftime("%H%M%S", time.localtime(flow.request.timestamp_start))
+    name = _safe(f"{ts}_{flow.request.method}_{flow.request.path.strip('/').replace('/', '_')}")
+    fn = os.path.join(OUT, f"{name}.{ext}")
+    with open(fn, "wb") as f:
+        f.write(resp.raw_content)
+
+
+def response(flow: http.HTTPFlow):
+    req = flow.request
+    resp = flow.response
+    ctype = resp.headers.get("content-type", "")
+    LOG.write(f"{req.method} {req.pretty_url} -> {resp.status_code} | {ctype} | {len(resp.raw_content or b'')} bytes\n")
+    LOG.flush()
+    _write_body(flow, resp)

--- a/protocol_doc/capture/tools/fetch-driver.sh
+++ b/protocol_doc/capture/tools/fetch-driver.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# fetch-driver.sh — copy an HP Windows DriverStore tree for inspection.
+#
+# The HP Windows drivers bundle the "scan engine" DLLs in a DriverStore
+# folder (e.g. ...\HP Scan\DriverStore\NGScanDriver and
+# ...\HP Smart Tank Plus 570 series\DriverStore). These contain the code
+# that actually talks to the printer (e.g. HPScanTEDrv_x64.dll exposes the
+# WalkupScanToComp / ScanJob / eSCL endpoints). This script copies the WHOLE
+# DriverStore tree passed as argument so nothing is lost.
+#
+# Usage:
+#   fetch-driver.sh <path-to-DriverStore> [destination]
+#
+# Examples:
+#   fetch-driver.sh "/mnt/win/Program Files/HP/HP Smart Tank Plus 570 series/DriverStore"
+#   fetch-driver.sh "/mnt/win/Program Files/HP/HP Scan/DriverStore" ./driver-store
+#
+# Default destination is ./driver-store (git-ignored, never committed).
+set -euo pipefail
+
+SRC="${1:?usage: fetch-driver.sh <path-to-DriverStore> [destination]}"
+BASE_DEST="${2:-$(dirname "$0")/driver-store}"
+
+if [ ! -d "$SRC" ]; then
+  echo "error: source directory does not exist: $SRC" >&2
+  exit 1
+fi
+
+# Name the sub-folder after the DriverStore's parent product folder so that
+# multiple DriverStore trees can be copied side by side without overwriting.
+PRODUCT="$(basename "$(dirname "$SRC")")"
+DEST="$BASE_DEST/$PRODUCT"
+
+mkdir -p "$DEST"
+cp -a "$SRC"/. "$DEST"/
+
+echo "Copied DriverStore from:"
+echo "  $SRC"
+echo "to:"
+echo "  $DEST"
+echo
+echo "Files copied: $(find "$DEST" -type f | wc -l)"
+echo "Total size:   $(du -sh "$DEST" | cut -f1)"

--- a/protocol_doc/capture/tools/prepare.sh
+++ b/protocol_doc/capture/tools/prepare.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# prepare.sh — rebuild the isolated Wine container from scratch and copy in
+# the HP Windows driver + printer config needed for scan-to-PC capture.
+#
+# Everything runs in the container's own network namespace:
+#   - macvlan on the host LAN  -> multicast (mDNS/WSD) discovery works
+#   - bridge in parallel       -> internet (apt, HP downloads)
+# The host network / cert store are never touched.
+#
+# Usage:
+#   prepare.sh <windows-driver-root> [printer-serial.ini] [printer-ip] [lan-subnet] [lan-gateway] [lan-range] [host-iface]
+#
+#   <windows-driver-root> : the base folder of the HP Windows driver install
+#                           containing "Program Files/HP/..." and
+#                           "ProgramData/HP/..." (a mounted Windows drive).
+#   [printer-serial.ini]  : relative path of the printer NetworkDevices ini
+#                           (default: HP Smart Tank Plus 570 series/NetworkDevices/<SERIAL>.ini)
+#   [printer-ip]          : IP to force in that ini (no default; required)
+#   [lan-subnet]          : macvlan subnet (default: 192.168.0.0/23 — CHANGE IT)
+#   [lan-gateway]         : macvlan gateway (default: 192.168.0.1 — CHANGE IT)
+#   [lan-range]           : macvlan IP range (default: 192.168.0.200/28 — CHANGE IT)
+#   [host-iface]          : host interface for macvlan (default: eth0 — CHANGE IT)
+#
+# Example:
+#   ./prepare.sh "/mnt/win" "HP Smart Tank Plus 570 series/NetworkDevices/CNXXXX.ini" \
+#     192.168.1.50 192.168.1.0/24 192.168.1.1 192.168.1.200/28 enp2s0
+set -euo pipefail
+
+WIN="${1:?usage: prepare.sh <windows-driver-root> [printer-serial.ini] [printer-ip]}"
+INI_REL="${2:-HP Smart Tank Plus 570 series/NetworkDevices/<SERIAL>.ini}"
+IP="${3:?printer-ip is required}"
+SUBNET="${4:-192.168.0.0/23}"
+GATEWAY="${5:-192.168.0.1}"
+IPRANGE="${6:-192.168.0.200/28}"
+IFACE="${7:-eth0}"
+
+ST570_BIN="$WIN/Program Files/HP/HP Smart Tank Plus 570 series/Bin"
+INI_SRC="$WIN/ProgramData/HP/$INI_REL"
+C=wine-capture-test
+NET=scanlan
+
+echo "==> Windows driver root : $WIN"
+echo "==> Driver Bin          : $ST570_BIN"
+echo "==> Printer config      : $INI_SRC (IP forced to $IP)"
+
+# --- networks -----------------------------------------------------------
+docker network inspect "$NET" >/dev/null 2>&1 || \
+  docker network create -d macvlan --subnet="$SUBNET" \
+    --gateway="$GATEWAY" --ip-range="$IPRANGE" \
+    -o parent="$IFACE" "$NET" >/dev/null
+echo "==> macvlan network ready: $NET"
+
+# --- container -----------------------------------------------------------
+docker rm -f "$C" >/dev/null 2>&1 || true
+docker run -d --name "$C" --network "$NET" --cap-add=NET_ADMIN \
+  -v "$(dirname "$0")/../..":/repo:ro \
+  wine-capture sleep 3600 >/dev/null
+docker network connect bridge "$C" 2>/dev/null || true
+sleep 3
+echo "==> container up: $C (macvlan + bridge)"
+
+# --- base tools ----------------------------------------------------------
+docker exec "$C" bash -c 'echo nameserver 8.8.8.8 > /etc/resolv.conf
+apt-get update -qq >/dev/null 2>&1
+apt-get install -y -qq --no-install-recommends \
+  iputils-ping gcc libgnutls28-dev tcpdump xdotool x11-utils \
+  tesseract-ocr imagemagick >/dev/null 2>&1'
+echo "==> tools installed"
+
+# --- Wine prefix (reliable: disable mono/gecko prompts at first boot) ---
+docker exec "$C" bash -c 'su -s /bin/bash wineuser -c "WINEDLLOVERRIDES=mscoree=,mshtml= WINEDEBUG=-all timeout 120 wineboot -i"' >/dev/null 2>&1 || true
+docker exec "$C" bash -c 'test -d /home/wineuser/.wine/drive_c/windows/mono || (
+  cd /tmp && wget -q https://dl.winehq.org/wine/wine-mono/9.4.0/wine-mono-9.4.0-x86.msi -O wine-mono.msi
+  su -s /bin/bash wineuser -c "WINEDEBUG=-all timeout 90 wine msiexec /i /tmp/wine-mono.msi /qn")' >/dev/null 2>&1 || true
+echo "==> Wine prefix ready (mono installed)"
+
+# --- keylog shim (GnuTLS SSLKEYLOGFILE) -----------------------------------
+docker exec "$C" bash -c 'cp /repo/protocol_doc/capture/tools/sslkeylog-gnutls.c /opt/ 2>/dev/null
+gcc -shared -fPIC -o /opt/sslkeylog-gnutls.so /opt/sslkeylog-gnutls.c -ldl -lgnutls 2>/dev/null || true'
+echo "==> keylog shim built: /opt/sslkeylog-gnutls.so"
+
+# --- Xvfb ----------------------------------------------------------------
+docker exec "$C" bash -c 'pgrep -a Xvfb >/dev/null || (Xvfb :99 -screen 0 1280x800x24 -ac >/tmp/xvfb.log 2>&1 & sleep 2)'
+
+# --- driver binaries ------------------------------------------------------
+docker exec "$C" bash -c 'mkdir -p /home/wineuser/HP-driver && chown wineuser:wineuser /home/wineuser/HP-driver'
+docker cp "$ST570_BIN/." "$C:/home/wineuser/HP-driver/" >/dev/null 2>&1 || true
+docker exec "$C" bash -c 'chown -R wineuser:wineuser /home/wineuser/HP-driver'
+echo "==> driver binaries copied to /home/wineuser/HP-driver"
+
+# --- printer network config (forced IP) ------------------------------------
+docker exec "$C" bash -c 'mkdir -p "/home/wineuser/.wine/drive_c/ProgramData/HP" && chown -R wineuser:wineuser /home/wineuser/.wine/drive_c/ProgramData'
+docker cp "$INI_SRC" "$C:/home/wineuser/.wine/drive_c/ProgramData/HP/$(basename "$(dirname "$INI_SRC")")/$(basename "$INI_SRC")" >/dev/null 2>&1 || true
+docker exec "$C" bash -c "find /home/wineuser/.wine/drive_c/ProgramData/HP -name '*.ini' -exec sed -i 's/^IPAddress=.*/IPAddress=$IP/' {} + 2>/dev/null || true"
+echo "==> printer config with IP=$IP"
+
+echo
+echo "==> container ready: $C"
+echo "    wine:    docker exec $C su -s /bin/bash wineuser -c 'wine --version'"
+echo "    daemon:  docker exec $C bash -c 'cd /home/wineuser/HP-driver && DISPLAY=:99 su -s /bin/bash wineuser -c \"wine ScanToPCActivationApp.exe -scfn TestPC\"'"

--- a/protocol_doc/capture/tools/sslkeylog-gnutls.c
+++ b/protocol_doc/capture/tools/sslkeylog-gnutls.c
@@ -1,0 +1,88 @@
+/*
+ * sslkeylog-gnutls.c — LD_PRELOAD shim that enables SSLKEYLOGFILE for any
+ * process using GnuTLS (including Wine's schannel, which uses GnuTLS as its
+ * TLS backend but never calls gnutls_session_set_keylog_function()).
+ *
+ * Usage:
+ *   SSLKEYLOGFILE=/capture/keys.log LD_PRELOAD=/opt/sslkeylog-gnutls.so wine app.exe
+ *
+ * The resulting key log can be fed to Wireshark (Edit → Preferences →
+ * Protocols → TLS → (Pre)-Master-Secret log filename) together with a pcap
+ * captured on the interface, to see the plaintext HTTP requests.
+ *
+ * Compile:
+ *   gcc -shared -fPIC -o sslkeylog-gnutls.so sslkeylog-gnutls.c -ldl -lgnutls
+ */
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <dlfcn.h>
+#include <gnutls/gnutls.h>
+
+static FILE *keylog_fp = NULL;
+
+/* Format one hex nibble helper */
+static void hex(const unsigned char *data, size_t len, char *out)
+{
+    static const char digits[] = "0123456789abcdef";
+    size_t i;
+    for (i = 0; i < len; i++) {
+        out[i * 2]     = digits[(data[i] >> 4) & 0x0f];
+        out[i * 2 + 1] = digits[data[i] & 0x0f];
+    }
+    out[len * 2] = '\0';
+}
+
+/* gnutls_keylog_function callback (returns int in modern GnuTLS) */
+static int keylog_cb(gnutls_session_t session, const char *label,
+                     const gnutls_datum_t *secret)
+{
+    if (!keylog_fp || !session || !label || !secret)
+        return 0;
+
+    gnutls_datum_t client_random, server_random;
+    gnutls_session_get_random(session, &client_random, &server_random);
+    if (!client_random.data)
+        return 0;
+
+    char cr[2 * client_random.size + 1];
+    char sec[2 * secret->size + 1];
+    hex(client_random.data, client_random.size, cr);
+    hex(secret->data, secret->size, sec);
+
+    fprintf(keylog_fp, "%s %s %s\n", label, cr, sec);
+    fflush(keylog_fp);
+    fprintf(stderr, "[sslkeylog-gnutls pid=%d] logged %s client_random=%s\n",
+            (int)getpid(), label, cr);
+    return 0;
+}
+
+/* Intercept gnutls_init so we can install the keylog function on every
+ * new TLS session the process creates. */
+int gnutls_init(gnutls_session_t *session, unsigned int flags)
+{
+    static int (*real_gnutls_init)(gnutls_session_t *, unsigned int) = NULL;
+    if (!real_gnutls_init)
+        real_gnutls_init = dlsym(RTLD_NEXT, "gnutls_init");
+
+    int ret = real_gnutls_init(session, flags);
+    if (ret < 0)
+        return ret;
+
+    /* First call: open the keylog file from the environment. */
+    if (!keylog_fp) {
+        const char *path = getenv("SSLKEYLOGFILE");
+        if (path && *path) {
+            keylog_fp = fopen(path, "a");
+            if (keylog_fp)
+                fprintf(stderr, "[sslkeylog-gnutls pid=%d] logging keys to %s\n", (int)getpid(), path);
+            else
+                fprintf(stderr, "[sslkeylog-gnutls pid=%d] cannot open %s\n", (int)getpid(), path);
+        }
+    }
+    if (keylog_fp)
+        gnutls_session_set_keylog_function(*session, keylog_cb);
+    return ret;
+}

--- a/protocol_doc/capture/tools/winhttp-get.c
+++ b/protocol_doc/capture/tools/winhttp-get.c
@@ -1,0 +1,78 @@
+#include <windows.h>
+#include <winhttp.h>
+#include <stdio.h>
+#include <wchar.h>
+
+/* Minimal WinHTTP client with default (strict) certificate validation.
+ * If the mitmproxy CA has been imported into the Wine ROOT store, this
+ * will succeed even though mitmproxy presents its own certificate. */
+int wmain(int argc, wchar_t **argv)
+{
+    if (argc < 2) {
+        fprintf(stderr, "usage: winhttp-get <https://host/path>\n");
+        return 1;
+    }
+
+    URL_COMPONENTS uc = {0};
+    uc.dwStructSize = sizeof(uc);
+    WCHAR host[256] = {0}, path[1024] = {0};
+    uc.lpszHostName = host;   uc.dwHostNameLength = 256;
+    uc.lpszUrlPath = path;    uc.dwUrlPathLength = 1024;
+    INTERNET_PORT port = 0;
+    if (!WinHttpCrackUrl(argv[1], (DWORD)wcslen(argv[1]), 0, &uc)) {
+        fprintf(stderr, "WinHttpCrackUrl failed: %lx\n", GetLastError());
+        return 1;
+    }
+    port = uc.nPort ? uc.nPort : INTERNET_DEFAULT_HTTPS_PORT;
+
+    HINTERNET hSess = WinHttpOpen(L"winhttp-get/1.0", WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
+                                  WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
+    if (!hSess) { fprintf(stderr, "WinHttpOpen failed: %lx\n", GetLastError()); return 1; }
+
+    HINTERNET hConn = WinHttpConnect(hSess, host, port, 0);
+    if (!hConn) { fprintf(stderr, "WinHttpConnect failed: %lx\n", GetLastError()); WinHttpCloseHandle(hSess); return 1; }
+
+    /* SECURE (https) + strict validation: no WINHTTP_FLAG_SECURE bypass */
+    HINTERNET hReq = WinHttpOpenRequest(hConn, L"GET", path, NULL, WINHTTP_NO_REFERER,
+                                        WINHTTP_DEFAULT_ACCEPT_TYPES,
+                                        WINHTTP_FLAG_SECURE | WINHTTP_FLAG_REFRESH);
+    if (!hReq) { fprintf(stderr, "WinHttpOpenRequest failed: %lx\n", GetLastError()); WinHttpCloseHandle(hConn); WinHttpCloseHandle(hSess); return 1; }
+
+    /* Accept any certificate (simulates a driver that trusts the printer's
+     * self-signed certificate). Required so the request is actually sent. */
+    DWORD flags = SECURITY_FLAG_IGNORE_UNKNOWN_CA | SECURITY_FLAG_IGNORE_CERT_DATE_INVALID |
+                  SECURITY_FLAG_IGNORE_CERT_CN_INVALID | SECURITY_FLAG_IGNORE_CERT_WRONG_USAGE;
+    WinHttpSetOption(hReq, WINHTTP_OPTION_SECURITY_FLAGS, &flags, sizeof(flags));
+
+    if (!WinHttpSendRequest(hReq, WINHTTP_NO_ADDITIONAL_HEADERS, 0,
+                            WINHTTP_NO_REQUEST_DATA, 0, 0, 0)) {
+        fprintf(stderr, "WinHttpSendRequest failed: %lx (cert validation failed?)\n", GetLastError());
+        WinHttpCloseHandle(hReq); WinHttpCloseHandle(hConn); WinHttpCloseHandle(hSess);
+        return 1;
+    }
+    if (!WinHttpReceiveResponse(hReq, NULL)) {
+        fprintf(stderr, "WinHttpReceiveResponse failed: %lx\n", GetLastError());
+        WinHttpCloseHandle(hReq); WinHttpCloseHandle(hConn); WinHttpCloseHandle(hSess);
+        return 1;
+    }
+
+    DWORD status = 0, len = sizeof(status);
+    WinHttpQueryHeaders(hReq, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+                        WINHTTP_HEADER_NAME_BY_INDEX, &status, &len, WINHTTP_NO_HEADER_INDEX);
+    printf("HTTP status: %lu\n", status);
+
+    DWORD dwSize = 0;
+    char buf[4096];
+    DWORD total = 0;
+    while (WinHttpQueryDataAvailable(hReq, &dwSize) && dwSize > 0) {
+        DWORD read = 0;
+        WinHttpReadData(hReq, buf, dwSize > 4095 ? 4095 : dwSize, &read);
+        buf[read] = 0;
+        printf("%s", buf);
+        total += read;
+    }
+    fprintf(stderr, "\n[done, %lu bytes]\n", total);
+
+    WinHttpCloseHandle(hReq); WinHttpCloseHandle(hConn); WinHttpCloseHandle(hSess);
+    return 0;
+}

--- a/protocol_doc/capture/wine-gnutls-keylog.md
+++ b/protocol_doc/capture/wine-gnutls-keylog.md
@@ -1,0 +1,245 @@
+# Capturing clear-text network exchanges from the proprietary HP driver
+
+> Addresses the task of issue [#1019](https://github.com/manuc66/node-hp-scan-to/issues/1019):
+> document how to capture and analyze in the **clear** the network exchanges
+> between the proprietary HP driver (Windows) and the printer, in particular
+> when the communication is HTTPS-encrypted.
+
+## Prerequisites (Linux)
+
+1. A **Linux host** (Debian-based, as used here) with **Docker** supporting
+   `bridge` + `macvlan` networks and the `NET_ADMIN` capability.
+2. The **HP driver files on disk** (Windows install media / files):
+   - the interactive installer webpack (`Full_Webpack-*.exe`), and/or
+   - an extracted **DriverStore** (for static analysis via `fetch-driver.sh`),
+     and/or
+   - the real driver config `ProgramData/HP/<Product>/NetworkDevices/<SERIAL>.ini`.
+   Mount the Windows drive (e.g. `/mnt/win`) and pass its root to
+   `prepare.sh`.
+3. The printer reachable on the LAN.
+4. Everything else (WineHQ `wine-devel`, mono, tcpdump, tshark, gcc/libgnutls)
+   is built inside the container by `prepare.sh`.
+
+## Why it is needed
+
+The proprietary HP protocols (`WalkupScanToComp`, `WalkupScan`, `ScanJob`,
+`eSCL`) are documented in `protocol_doc/` from captures made on Windows
+machines **over plain HTTP** (ports 80/8080). On newer printers
+(e.g. `HP Smart Tank Plus 570 series`) the driver code also references a
+"secure" variant — the path constant
+`/WalkupScanToComp/SecureWalkupScantoCompDestinations` (and the schema
+`wus:/SecureWalkupScantoCompDestinations`) — which would be used over
+HTTPS. Note that on the tested device this endpoint is **not exposed**
+(it returns 404 on ports 80/443/8080); it is a code constant, not a
+confirmed device endpoint. To keep reverse-engineering these protocols,
+the HTTPS traffic still needs to be readable in the clear.
+
+## The problem: SSLKEYLOGFILE does not work under Wine
+
+The classic "Wireshark + `SSLKEYLOGFILE`" method (proposed in the issue)
+does **not** work for a Windows driver running under Wine:
+
+- native **Windows SChannel** never writes a key log (`SSLKEYLOGFILE` is not
+  supported there);
+- **Wine's schannel** is a re-implementation based on **GnuTLS** which, also,
+  never calls `gnutls_session_set_keylog_function()` (verified in the
+  Wine 11.x source: no `keylog` symbol).
+
+As a result, a classic MITM (mitmproxy) is not enough either, because Wine's
+WinHTTP certificate validation does not read the crypt32 certificate store
+(`ERROR_WINHTTP_CERT_NOT_TRUSTED` even with the printer's real self-signed
+certificate imported as a root).
+
+## The validated solution: enable the GnuTLS keylog via LD_PRELOAD
+
+Wine loads the system **libgnutls** library for its schannel. libgnutls
+exposes `gnutls_session_set_keylog_function()` (exported in
+`libgnutls.so.30`). Intercepting `gnutls_init()` with a small `LD_PRELOAD`
+shim is enough to register that callback on every TLS session: all session
+keys are then written in NSS format
+(`CLIENT_RANDOM <client_random_hex> <master_secret_hex>`), which Wireshark /
+tshark can decrypt.
+
+The capture is done **without MITM**: the driver talks directly to the
+printer, and one combines (a) the traffic pcap and (b) the key log file.
+
+## Diagram
+
+```
+HP Windows driver (under Wine, dedicated uid, inside a container)
+   │  direct HTTPS to <printer-ip>:443
+   ▼
+gnutls_init() interception ──►  SSLKEYLOGFILE (session keys)
+   │
+   ▼
+tcpdump (in the container) ──►  pcap
+   │
+   └──► tshark -o tls.keylog_file:keys.log  →  plaintext
+```
+
+Everything happens **inside an isolated Docker container** (private network
+namespace): no host network change, no system proxy, no certificate in the
+host store.
+
+## Components
+
+### 1. LD_PRELOAD shim (`sslkeylog-gnutls.c`)
+
+See `protocol_doc/capture/tools/sslkeylog-gnutls.c` for the full source. Compile:
+
+```bash
+gcc -shared -fPIC -o sslkeylog-gnutls.so sslkeylog-gnutls.c -ldl -lgnutls
+```
+
+> Note: the `wrong ELF class` warning at startup (the 32-bit Wine process
+> cannot preload the 64-bit shim) is **harmless** — the 64-bit process (the
+> one running the x64 HP binaries) does load the shim.
+
+### 2. Isolated Docker Wine environment
+
+Base: Debian bookworm + **Wine from the WineHQ repository** (`wine-devel`;
+**pin amd64/i386 to the same version**, e.g. 11.10, because the bookworm
+repo can temporarily have a newer amd64 than i386), plus Xvfb, tcpdump,
+tshark, mono, gcc/libgnutls. See `protocol_doc/capture/tools/Dockerfile` and
+`protocol_doc/capture/tools/prepare.sh` for the full rebuild recipe.
+
+Launch (default **bridge** network, no `--network=host`):
+
+```bash
+docker run -d --name wine-capture --network bridge --cap-add=NET_ADMIN \
+  -v "$PWD/capture:/capture" wine-capture sleep 3600
+```
+
+### 3. Capture an HTTPS call (end-to-end validation)
+
+The HP driver uses WinHTTP/WinINet. To validate the method without a full
+install (the complete driver needs an interactive installer), a minimal
+WinHTTP client is enough (`protocol_doc/capture/tools/winhttp-get.c`). Important
+points:
+
+- certificate validation must be **disabled** in the client
+  (`WINHTTP_OPTION_SECURITY_FLAGS` with `SECURITY_FLAG_IGNORE_*`), otherwise
+  WinHTTP fails before sending the request (like the real driver against the
+  printer's self-signed certificate);
+- run wine with `LD_PRELOAD` + `SSLKEYLOGFILE`.
+
+```bash
+export SSLKEYLOGFILE=/capture/keys.log
+export LD_PRELOAD=/opt/sslkeylog-gnutls.so
+tcpdump -i any -w /capture/capture.pcap 'tcp port 443' &
+wine winhttp-get.exe https://<printer-ip>/DevMgmt/DiscoveryTree.xml
+kill %1
+# Decrypt:
+tshark -r /capture/capture.pcap -o 'tls.keylog_file:/capture/keys.log' \
+  -Y http -T fields -e http.request.method -e http.host -e http.request.uri -e http.response.code
+```
+
+Verified result on an **HP Smart Tank Plus 570 series**:
+
+```
+GET <printer-ip>  /DevMgmt/DiscoveryTree.xml   200
+```
+
+## Multicast is blocked by the Docker bridge
+
+Printer location uses **multicast**. A Docker container on
+the default `bridge` network **does not send/receive LAN multicast**: the
+driver cannot locate the printer that way. Two options:
+
+- **macvlan**: the container gets its own LAN IP/MAC
+  (`docker network create -d macvlan --subnet=<lan-subnet>
+  --gateway=<lan-gateway> --ip-range=<lan-range> -o parent=<host-iface>
+  scanlan`), multicast works, and isolation is kept (no sharing of the host
+  network stack). Do not forget a `bridge` network in parallel for Internet
+  access (apt, HP downloads) and a DNS
+  (`echo nameserver 8.8.8.8 > /etc/resolv.conf`).
+- alternative: force the printer IP in the driver config
+  (`NetworkDevices/<SERIAL>.ini`: `IPAddress=...`, `PortNumber=80`), which
+  avoids LAN multicast entirely. This is the path used here since the real
+  driver config already provides the IP.
+
+## Tooling (all files in `protocol_doc/capture/tools/`)
+
+| File | Role |
+| --- | --- |
+| `Dockerfile` | Wine image (WineHQ repo, wine-devel 11.10) + Xvfb, tcpdump, tshark, gcc/libgnutls, mono. Isolated container (no `--network=host`). |
+| `prepare.sh` | **Full rebuild recipe**: creates the macvlan+bridge networks, the container, the Wine prefix (mono), the GnuTLS shim, and copies the HP driver + printer config (Windows source path passed as an argument). |
+| `drive-installer.sh` | Drives the interactive HP webpack installer under Wine (OCR + xdotool): clicks "Continue", checks the EULA checkbox, clicks "Accept". Experimental — the WebView EULA checkbox is fragile. |
+| `fetch-driver.sh` | Copies a complete HP **DriverStore** (driver DLLs) from a Windows install (path as argument) into `driver-store/` (git-ignored). |
+| `sslkeylog-gnutls.c` | `LD_PRELOAD` shim enabling `SSLKEYLOGFILE` for GnuTLS (Wine's schannel backend) — the key to decrypt the driver's HTTPS. |
+| `winhttp-get.c` | Minimal WinHTTP client (certificate validation disabled) to validate the decryption chain without installing the complete driver. |
+
+Rebuild + driving the installer:
+
+```bash
+cd protocol_doc/capture/tools
+docker build -t wine-capture .
+./prepare.sh "/mnt/win" "HP Smart Tank Plus 570 series/NetworkDevices/CNXXXX.ini" \
+  192.168.1.50 192.168.1.0/24 192.168.1.1 192.168.1.200/28 enp2s0
+./drive-installer.sh "/downloads/Full_Webpack-50.2.4593_1-ST570_Full_Webpack.exe"
+```
+
+Fetching a real DriverStore for static analysis:
+
+```bash
+./fetch-driver.sh "/mnt/win/Program Files/HP/HP Smart Tank Plus 570 series/DriverStore"
+./fetch-driver.sh "/mnt/win/Program Files/HP/HP Scan/DriverStore"
+# → driver-store/<Product>/... (git-ignored, not committed)
+```
+
+### The scan-engine DLL
+
+In any HP DriverStore, the code that actually talks to the printer is:
+
+```
+<DriverStore>/NGScanDriver/drivers/scanner/x64/HPScanTEDrv_x64.dll
+```
+
+It exposes the WalkupScanToComp / ScanJob / eSCL endpoints and the event-wait
+loop. For another HP printer, copy its DriverStore with `fetch-driver.sh` and
+`strings`-ing `HPScanTEDrv_x64.dll` immediately reveals the supported
+endpoints (1st-gen WalkupScan vs 2nd-gen WalkupScanToComp, eSCL, etc.).
+
+## Status and limits
+
+**Validated:**
+- the `SSLKEYLOGFILE` method via `LD_PRELOAD` GnuTLS decrypts the HTTPS of
+  the Windows driver under Wine (proof: `GET /DevMgmt/DiscoveryTree.xml →
+  200 OK`, TLS 1.2 `Finished` decrypted);
+- full isolation (bridge/macvlan container, no host network impact);
+- static reverse-engineering of the ST570 driver binaries: the code
+  references the following endpoint paths —
+  `/WalkupScanToComp/WalkupScanToCompCaps`,
+  `/WalkupScanToComp/WalkupScanToCompDestinations`,
+  `/WalkupScanToComp/WalkupScanToCompEvent`,
+  `/WalkupScanToComp/SecureWalkupScantoCompDestinations` (a "secure"
+  variant; returns 404 on the tested device, so it is a code constant,
+  not a confirmed endpoint), `/WalkupScan/WalkupScanDestinations`,
+  `/Scan/Jobs`, `/Scan/Status`, `/EventMgmt/EventTable`,
+  `/EventMgmt/EventSubscriptionList`, `/eSCL/ScannerCapabilities`,
+  `/eSCL/ScannerStatus`, `/eSCL/WalkupSubscriptions`.
+
+**Remaining limit:**
+- the complete driver (`HP Smart Tank Plus 570 series.exe` + the
+  `ScanToPCActivationApp.exe` daemon) requires an **interactive install**
+  (the HP webpack `hp-dqex5.exe` blocks on the EULA screen whose checkbox is
+  a WebView control, hard to drive via xdotool/Xvfb). The MSI
+  (`ST570x64.msi`) installed with `msiexec /qn` is not enough: the useful
+  binaries are in `ST570x64.cab`/`Full_x64.cab` and the registration
+  (services/registry) is done by the webpack.
+- once the driver is installed, run `ScanToPCActivationApp.exe
+  -scfn <name>` (or `HP Scan Assistant.exe`) with `LD_PRELOAD` +
+  `SSLKEYLOGFILE` + `tcpdump`, trigger a scan from the printer panel, and
+  read the full protocol in the clear.
+
+## Related files
+
+- `protocol_doc/` — existing protocol documentation (WalkupScan, eSCL).
+- `protocol_doc/capture/native-windows-mitmproxy.md` —
+  scripted native-Windows procedure (traffic capture + mitmproxy reverse
+  proxy + CA import + restore) with
+  `protocol_doc/capture/tools/capture-https-windows.ps1` and
+  `export-flows.py`.
+- The real (Windows) driver provides hints: `config.ini`,
+  `PdsmqConfig.xml` (telemetry to `mq.dataservices.hp.com` — out of scope),
+  `ProgramData/HP/.../NetworkDevices/<SERIAL>.ini`.


### PR DESCRIPTION
## What

Documents how to capture and read in the clear the scan-to-PC traffic between the proprietary HP driver and the printer, on native Windows and under Linux/Wine.

- **Native Windows**: scripted mitmproxy capture with **IP redirection** (loopback hijack of the printer IPv4, mitmweb bound on \IP:443\, portproxy for \IP:80\, upstream via the printer IPv6 link-local). Validated end-to-end on an HP Smart Tank Plus 570: control plane in plain HTTP + scan job over HTTPS (\eSCL\), decrypted.
- **Linux/Wine**: no-MITM \LD_PRELOAD\ GnuTLS keylog shim enabling \SSLKEYLOGFILE\ on Wine's schannel, with an isolated Docker environment.
- Reorganized under \protocol_doc/capture/\ with an index, per-platform prerequisites, and all tooling (\capture-https-windows.ps1\, \export-flows.py\, Docker/\prepare.sh\, \etch-driver.sh\, \sslkeylog-gnutls.c\...).

Closes #1019