### PR TITLE
feat(webhook): durable outbox with retry and dead-letter (opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,17 @@ All notable changes to this project are documented in this file.
 
 - **Webhook notifications**: every completed scan POSTs a JSON event
   (`scan-completed`, or `scan-delivery-failed` when a delivery target failed)
-  to a configurable URL, carrying the scan metadata, per-page descriptors, the
-  outcome of each delivery target and one descriptor per file (name, size,
-  SHA-256 and where to fetch it: local path, S3 `bucket`/`key` or Nextcloud
-  WebDAV URL). Events are signed with HMAC-SHA256 (custom header supported) or
-  authenticated with bearer/basic auth, sent with an `idempotency-key` header;
-  delivery is best-effort (a single POST, failures are logged). Configured
-  with the new `--webhook-*` CLI options, the matching `webhook_*` config file
-  keys or the `WEBHOOK_*` environment variables (Docker). The event contract
-  is described in `protocol_doc/webhook/openapi.yaml`.
+  to a configurable URL, carrying the scan metadata, the outcome of each
+  delivery target and one descriptor per file (name, size, SHA-256 and where
+  to fetch it: local path, S3 `bucket`/`key` or Nextcloud WebDAV URL). Events
+  are signed with HMAC-SHA256 (custom header supported) or authenticated with
+  bearer/basic auth, sent with an `idempotency-key` header and durably queued
+  in an outbox: delivery failures (5xx, 429, timeouts) are retried at startup
+  and after each scan, and events that keep failing are dead-lettered to
+  `<id>.failed.json` instead of being lost. Configured with the new
+  `--webhook-*` CLI options, the matching `webhook_*` config file keys or the
+  `WEBHOOK_*` environment variables (Docker). The event contract is described
+  in `protocol_doc/webhook/openapi.yaml`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ There is a good chance it also works on other unlisted HP All-in-One Printer.
   - [Paperless-ngx API](https://docs.paperless-ngx.com/api/) upload
   - [Nextcloud WebDAV](https://docs.Nextcloud.com/server/latest/user_manual/en/files/access_webdav.html) upload
   - S3-compatible (AWS S3, MinIO, Cloudflare R2, Wasabi...) upload
-  - Webhook notification (JSON event with idempotency key, `scan-completed` /
-    `scan-delivery-failed` event types, per-page descriptors and delivery
-    outcomes). Each file carries `size`/`sha256` plus its location (`local`
-    path, S3 `bucket`/`key` or Nextcloud WebDAV URL); the event is a metadata
+  - Webhook notification (JSON event with idempotency key, outbox retries and
+    dead-letter; `scan-completed` / `scan-delivery-failed` event types). Each
+    file carries `size`/`sha256` plus its location (`local` path, S3
+    `bucket`/`key` or Nextcloud WebDAV URL); the event is a metadata
     notification, so with `--keep-files` disabled the local `path` may be
     cleaned up after a successful delivery. OpenAPI contract:
     [`protocol_doc/webhook/openapi.yaml`](protocol_doc/webhook/openapi.yaml).
@@ -304,13 +304,16 @@ Run `npx node-hp-scan-to --help` to see the full list of options below:
 | `--s3-prefix`                         | Folder (prefix) inside the bucket. Defaults to the bucket root.                                                                                                                                                                | `--s3-prefix 2026/08`                                              |
 | `--s3-force-path-style`               | Force path-style addressing (required for MinIO, Cloudflare R2, Wasabi...).                                                                                                                                                    | `--s3-force-path-style` (disabled by default)                     |
 | `--s3-session-token`                  | S3 session token for temporary credentials.                                                                                                                                                                                    | `--s3-session-token ...` (no default)                             |
-| `--webhook-url`                       | Webhook URL to POST scan events to (JSON with idempotency-key header).                                                                                           | `--webhook-url https://n8n.example/webhook/scan` (no default)      |
+| `--webhook-url`                       | Webhook URL to POST scan events to (JSON with idempotency-key header, outbox retries, dead-letter).                                                                                                                              | `--webhook-url https://n8n.example/webhook/scan` (no default)      |
 | `--webhook-auth`                      | Auth scheme for the webhook request: `none`, `hmac`, `bearer` or `basic` (default: inferred from the configured credentials).                                                                                                    | `--webhook-auth hmac` (auto)                                       |
 | `--webhook-auth-header`               | Header name carrying the HMAC signature.                                                                                                                                                                                         | `x-webhook-signature` (default)                                    |
 | `--webhook-secret`                    | HMAC-SHA256 signing secret, used as-is (not hex-decoded); the resulting signature is sent as hex in the auth header. Required unless `--webhook-secret-file` is used. Overrides if both are provided.                            | `--webhook-secret s3cr3t` (no default)                             |
 | `--webhook-secret-file`               | File containing the HMAC signing secret. Required unless `--webhook-secret` is used. Takes precedence if both are provided.                                                                                                      | `--webhook-secret-file /path/to/file` (no default)                 |
 | `--webhook-token`                     | Bearer token sent as `Authorization: Bearer <token>`.                                                                                                                                                                            | `--webhook-token tok...` (no default)                              |
 | `--webhook-username` / `--webhook-password` | Basic auth credentials sent as `Authorization: Basic`.                                                                                                                                                                     | `--webhook-username scanner --webhook-password ...` (no default)   |
+| `--webhook-outbox-dir`                | Directory where pending webhook events are stored until delivered. Only used when `--webhook-url` is set; default is enough on the host, mount a volume on Docker if you want events to survive container re-creation.           | `~/.node-hp-scan-to/outbox`                                        |
+| `--webhook-max-attempts`              | Max delivery attempts before an event is dead-lettered (only with `--webhook-durable-outbox`).                                                                                                                                  | `--webhook-max-attempts 5` (default 5)                             |
+| `--webhook-durable-outbox`            | Persist undelivered events in the outbox and retry them at startup and after each scan. Disabled by default: events are sent once and failures are only logged.                                                                 | `--webhook-durable-outbox` (disabled by default)                   |
 
 **Notes:**
 
@@ -471,6 +474,9 @@ Webhook Options:
   --webhook-token <webhook_token>                                  Bearer token sent as Authorization: Bearer <token>
   --webhook-username <webhook_username>                            Basic auth username sent as Authorization: Basic
   --webhook-password <webhook_password>                            Basic auth password for webhook-username
+  --webhook-outbox-dir <webhook_outbox_dir>                        Directory where pending events are stored until delivered (default: ~/.node-hp-scan-to/outbox)
+  --webhook-max-attempts <webhook_max_attempts>                    Max delivery attempts before dead-lettering an event (default: 5)
+  --webhook-durable-outbox                                         Persist undelivered events in the outbox and retry them at startup and after each scan. Disabled by default: events are sent once and failures are only logged.
 
 Device Control Screen Options:
   -l, --label <label>                                              The label to display on the device (the default is the hostname)
@@ -580,6 +586,9 @@ Webhook Options:
   --webhook-token <webhook_token>                                  Bearer token sent as Authorization: Bearer <token>
   --webhook-username <webhook_username>                            Basic auth username sent as Authorization: Basic
   --webhook-password <webhook_password>                            Basic auth password for webhook-username
+  --webhook-outbox-dir <webhook_outbox_dir>                        Directory where pending events are stored until delivered (default: ~/.node-hp-scan-to/outbox)
+  --webhook-max-attempts <webhook_max_attempts>                    Max delivery attempts before dead-lettering an event (default: 5)
+  --webhook-durable-outbox                                         Persist undelivered events in the outbox and retry them at startup and after each scan. Disabled by default: events are sent once and failures are only logged.
 
 Auto-scan Options:
   --pollingInterval <pollingInterval>                              Time interval in millisecond between each lookup for content in the automatic document feeder
@@ -699,6 +708,9 @@ Webhook Options:
   --webhook-token <webhook_token>                                  Bearer token sent as Authorization: Bearer <token>
   --webhook-username <webhook_username>                            Basic auth username sent as Authorization: Basic
   --webhook-password <webhook_password>                            Basic auth password for webhook-username
+  --webhook-outbox-dir <webhook_outbox_dir>                        Directory where pending events are stored until delivered (default: ~/.node-hp-scan-to/outbox)
+  --webhook-max-attempts <webhook_max_attempts>                    Max delivery attempts before dead-lettering an event (default: 5)
+  --webhook-durable-outbox                                         Persist undelivered events in the outbox and retry them at startup and after each scan. Disabled by default: events are sent once and failures are only logged.
 
 Global Options:
   -a, --address <ip>                                               IP address of the device, when specified, the ip will be used instead of the name
@@ -731,7 +743,7 @@ You could however use Docker's [macvlan](https://docs.docker.com/engine/network/
 
 All scanned files are written to the volume `/scan`, the filename can be changed with the `PATTERN` environment variable. For the correct permissions to the volume set the environment variables `PUID` and `PGID` to that of the user running the container (usually `PUID=1000` and `PGID=1000`).
 
-When `WEBHOOK_URL` is set, scan events are sent best-effort: a single POST per event, and failures are logged.
+When `WEBHOOK_URL` is set, scan events are sent best-effort by default: a single POST, and failures are logged. With `--webhook-durable-outbox` (or `WEBHOOK_DURABLE_OUTBOX`), events are written to an **outbox** before delivery (default `~/.node-hp-scan-to/outbox` inside the container), so a briefly unreachable receiver (n8n down, 429, timeout) does not drop the event: it is retried at startup and after each later scan, then dead-lettered to `<id>.failed.json`. That directory lives on the container writable layer, so `docker restart` keeps it, but **re-creating** the container (image update, `docker compose up --force-recreate`, `docker rm`) discards pending events. Mounting a volume and setting `WEBHOOK_OUTBOX_DIR` to that path is recommended if you want retries to survive those recreates.
 
 #### Docker Environment Variables
 
@@ -779,6 +791,9 @@ List of supported environment variables and their meaning, or correspondence wit
 | `WEBHOOK_TOKEN`               | Bearer token sent as `Authorization: Bearer`                                                                  | `--webhook-token`                                                             |
 | `WEBHOOK_USERNAME`            | Basic auth username sent as `Authorization: Basic`                                                            | `--webhook-username`                                                          |
 | `WEBHOOK_PASSWORD`            | Basic auth password for `WEBHOOK_USERNAME`                                                                    | `--webhook-password`                                                          |
+| `WEBHOOK_OUTBOX_DIR`          | Outbox directory (only when `WEBHOOK_URL` is set). Optional volume: recommended for new webhook usage so pending events survive image updates; existing setups without webhooks need none | `--webhook-outbox-dir`                                                        |
+| `WEBHOOK_MAX_ATTEMPTS`        | Max delivery attempts before an event is dead-lettered (only with `WEBHOOK_DURABLE_OUTBOX`; default `5`)     | `--webhook-max-attempts`                                                      |
+| `WEBHOOK_DURABLE_OUTBOX`      | Persist undelivered events and retry them (disabled by default)                                              | `--webhook-durable-outbox`                                                   |
 
 **Additional Notes:**
 

--- a/root/app.sh
+++ b/root/app.sh
@@ -131,8 +131,17 @@ if [ -n "$WEBHOOK_PASSWORD" ]; then
     ARGS+=("--webhook-password" "$WEBHOOK_PASSWORD")
 fi
 
+if [ -n "$WEBHOOK_OUTBOX_DIR" ]; then
+    ARGS+=("--webhook-outbox-dir" "$WEBHOOK_OUTBOX_DIR")
+fi
 
+if [ -n "$WEBHOOK_MAX_ATTEMPTS" ]; then
+    ARGS+=("--webhook-max-attempts" "$WEBHOOK_MAX_ATTEMPTS")
+fi
 
+if [ -n "${WEBHOOK_DURABLE_OUTBOX+x}" ] && [ "$WEBHOOK_DURABLE_OUTBOX" != "false" ] && [ "$WEBHOOK_DURABLE_OUTBOX" != "0" ]; then
+    ARGS+=("--webhook-durable-outbox")
+fi
 
 if [ -n "$CMDLINE" ]; then
     # Split CMDLINE into words and add to ARGS

--- a/src/program.ts
+++ b/src/program.ts
@@ -4,6 +4,7 @@
 "use strict";
 
 import os from "node:os";
+import path from "node:path";
 // default-import + destructure: this dependency is CommonJS and some loaders
 // (tsx) do not expose its named exports to ESM consumers
 import bonjourService from "bonjour-service";
@@ -37,6 +38,7 @@ import { ScanMode } from "./type/scanMode.js";
 import { DuplexAssemblyMode } from "./type/DuplexAssemblyMode.js";
 import { ScanFormat, parseScanFormat } from "./type/scanFormat.js";
 import { getLoggerForFile, setDebugLevel } from "./logger.js";
+import { flushOutbox } from "./webhook/webhook.js";
 
 const logger = getLoggerForFile(import.meta.url);
 function findOfficejetIp(deviceNamePrefix: string): Promise<string> {
@@ -341,6 +343,32 @@ function setupScanParameters(commandName: string) {
         "--webhook-password <webhook_password>",
         "Basic auth password for webhook-username",
       ).helpGroup(HelpGroupsHeadings.webhook),
+    )
+    .addOption(
+      new Option(
+        "--webhook-outbox-dir <webhook_outbox_dir>",
+        "Directory where pending events are stored until delivered (default: ~/.node-hp-scan-to/outbox)",
+      ).helpGroup(HelpGroupsHeadings.webhook),
+    )
+    .addOption(
+      new Option(
+        "--webhook-max-attempts <webhook_max_attempts>",
+        "Max delivery attempts before dead-lettering an event (default: 5)",
+      )
+        .argParser((value) => {
+          const parsed = Number.parseInt(value, 10);
+          if (!Number.isInteger(parsed) || parsed <= 0) {
+            throw new Error("webhook-max-attempts must be a positive integer");
+          }
+          return parsed;
+        })
+        .helpGroup(HelpGroupsHeadings.webhook),
+    )
+    .addOption(
+      new Option(
+        "--webhook-durable-outbox",
+        "Persist undelivered events in the outbox and retry them at startup and after each scan. Disabled by default: events are sent once and failures are only logged.",
+      ).helpGroup(HelpGroupsHeadings.webhook),
     );
 }
 
@@ -589,6 +617,16 @@ export function getWebhookConfig(
     return undefined;
   }
 
+  const outboxDir = getConfiguredValue(
+    options.webhookOutboxDir,
+    fileConfig.webhook_outbox_dir,
+    path.join(os.homedir(), ".node-hp-scan-to", "outbox"),
+  );
+  const maxAttempts = getConfiguredValue(
+    options.webhookMaxAttempts,
+    fileConfig.webhook_max_attempts,
+    5,
+  );
   const keepFiles: boolean = getConfiguredValue(
     options.keepFiles,
     fileConfig.keep_files,
@@ -654,13 +692,22 @@ export function getWebhookConfig(
     auth = "none";
   }
 
+  const durableOutbox: boolean = getConfiguredValue(
+    options.webhookDurableOutbox,
+    fileConfig.webhook_durable_outbox,
+    false,
+  );
+
   logger.info(
-    `Webhook configuration provided, url: ${webhookUrl}, auth: ${auth}, authHeader: ${authHeader}, keepFiles: ${keepFiles}`,
+    `Webhook configuration provided, url: ${webhookUrl}, auth: ${auth}, authHeader: ${authHeader}, durableOutbox: ${durableOutbox}, outbox: ${outboxDir}, maxAttempts: ${maxAttempts}, keepFiles: ${keepFiles}`,
   );
   const webhookConfig: WebhookConfig = {
     url: webhookUrl,
     auth,
     authHeader,
+    outboxDir,
+    maxAttempts,
+    durableOutbox,
     keepFiles,
   };
   if (secret !== undefined) {
@@ -936,6 +983,9 @@ function createListenCliCmd(configFile: FileConfig) {
 
       const scanConfig = getScanConfiguration(options, configFile);
 
+      if (scanConfig.webhookConfig) {
+        await flushOutbox(scanConfig.webhookConfig);
+      }
 
       await listenCmd(
         api,
@@ -1003,6 +1053,9 @@ function createAdfAutoscanCliCmd(fileConfig: FileConfig) {
 
       const scanConfig = getScanConfiguration(options, fileConfig);
 
+      if (scanConfig.webhookConfig) {
+        await flushOutbox(scanConfig.webhookConfig);
+      }
 
       const adfScanConfig: AdfAutoScanConfig = {
         ...scanConfig,
@@ -1077,6 +1130,9 @@ function createSingleScanCliCmd(fileConfig: FileConfig) {
 
       const scanConfig = getScanConfiguration(options, fileConfig);
 
+      if (scanConfig.webhookConfig) {
+        await flushOutbox(scanConfig.webhookConfig);
+      }
 
       const singleScanConfig: SingleScanConfig = {
         ...scanConfig,

--- a/src/type/FileConfig.ts
+++ b/src/type/FileConfig.ts
@@ -139,6 +139,9 @@ export const configSchema = z
     webhook_token: z.string().optional(), // Bearer token
     webhook_username: z.string().optional(), // Basic auth username
     webhook_password: z.string().optional(), // Basic auth password
+    webhook_outbox_dir: z.string().optional(), // Durable directory for pending events
+    webhook_max_attempts: z.number().int().positive().optional(), // Max delivery attempts
+    webhook_durable_outbox: z.boolean().optional(), // Persist undelivered events and retry them
 
     ///
     /// Common to external destination (paperless & nextcloud)

--- a/src/webhook/WebhookConfig.ts
+++ b/src/webhook/WebhookConfig.ts
@@ -15,6 +15,16 @@ export interface WebhookConfig {
   username?: string;
   /** Basic auth password. */
   password?: string;
+  /** Durable directory where pending events survive restarts. */
+  outboxDir: string;
+  /** Max delivery attempts before dead-lettering an event. */
+  maxAttempts: number;
+  /**
+   * When false (default) the event is sent best-effort: a single POST, logged
+   * on failure, nothing persisted. When true the event is written to the
+   * outbox first and retried at startup and after each scan.
+   */
+  durableOutbox: boolean;
   keepFiles: boolean;
 }
 

--- a/src/webhook/webhook.ts
+++ b/src/webhook/webhook.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 import { createHash, createHmac, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { existsSync } from "node:fs";
 import type { ScanContent } from "../type/ScanContent.js";
 import type { ScanMetadata } from "../type/ScanMetadata.js";
 import type { WebhookConfig } from "./WebhookConfig.js";
@@ -72,6 +73,16 @@ export interface WebhookPageDescriptor {
   sizeBytes?: number;
 }
 
+export interface EnqueuedEventFile {
+  id: string;
+  eventType: string;
+  createdAt: string;
+  attempts: number;
+  nextAttemptAt: string;
+  /** Raw payload body as sent (kept byte-for-byte for retries). */
+  payload: WebhookEvent;
+}
+
 function sha256Hex(data: Buffer): string {
   return createHash("sha256").update(data).digest("hex");
 }
@@ -127,8 +138,93 @@ function applyAuth(
   }
 }
 
+function outboxEntryPath(outboxDir: string, id: string): string {
+  return path.join(outboxDir, `${id}.json`);
+}
+
+function deadLetterPath(outboxDir: string, id: string): string {
+  return path.join(outboxDir, `${id}.failed.json`);
+}
+
+async function readOutboxEntry(
+  filePath: string,
+): Promise<EnqueuedEventFile | null> {
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    return JSON.parse(raw) as EnqueuedEventFile;
+  } catch (e) {
+    logger.error(e, `Failed to read outbox entry ${filePath}, skipping it`);
+    return null;
+  }
+}
+
+async function atomicallyWrite(
+  filePath: string,
+  content: string,
+): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.tmp`;
+  // 0600: outbox entries carry scan metadata and auth tokens, never world-readable.
+  await fs.writeFile(tmpPath, content, { encoding: "utf8", mode: 0o600 });
+  await fs.rename(tmpPath, filePath);
+}
+
+async function enqueueEvent(
+  webhookConfig: WebhookConfig,
+  payload: WebhookEvent,
+): Promise<void> {
+  const entry: EnqueuedEventFile = {
+    id: payload.id,
+    eventType: payload.type,
+    createdAt: new Date().toISOString(),
+    attempts: 0,
+    nextAttemptAt: new Date().toISOString(),
+    payload,
+  };
+  await atomicallyWrite(
+    outboxEntryPath(webhookConfig.outboxDir, payload.id),
+    JSON.stringify(entry),
+  );
+}
+
 /**
- * Best-effort delivery: a single POST, logged on failure, nothing persisted.
+ * Sends the event once. Returns "success", "dead-letter" or "retry".
+  * "success": 2xx (and other non-error statuses). "dead-letter": permanent 4xx
+  * (except 429/408 which are transient). "retry": 408/429/5xx, redirects (3xx),
+  * timeout or network failure — the entry stays in the outbox for a later attempt.
+  */
+async function deliverEvent(
+  webhookConfig: WebhookConfig,
+  entry: EnqueuedEventFile,
+): Promise<"success" | "dead-letter" | "retry"> {
+  try {
+    const status = await sendEventOnce(webhookConfig, entry.id, entry.payload);
+    if (status >= 200 && status < 300) {
+      logger.info(`Webhook acknowledged event ${entry.id}`);
+      return "success";
+    }
+    if (
+      (status >= 300 && status < 400) ||
+      status === 408 ||
+      status === 429 ||
+      status >= 500
+    ) {
+      logger.warn(`Webhook responded ${status}, event will be retried`);
+      return "retry";
+    }
+    logger.warn(
+      `Webhook rejected event ${entry.id} with ${status}, dead-lettering it`,
+    );
+    return "dead-letter";
+  } catch (error) {
+    logger.error(error, `Webhook delivery failed for event ${entry.id}`);
+    return "retry";
+  }
+}
+
+/**
+ * Best-effort delivery used when the durable outbox is disabled: a single
+ * POST, logged on failure, nothing persisted.
  */
 async function deliverBestEffort(
   webhookConfig: WebhookConfig,
@@ -177,6 +273,93 @@ async function sendEventOnce(
     validateStatus: () => true,
   });
   return response.status;
+}
+
+async function removeOutboxEntry(outboxDir: string, id: string): Promise<void> {
+  await fs.rm(outboxEntryPath(outboxDir, id), { force: true });
+}
+
+async function deadLetterEntry(
+  outboxDir: string,
+  id: string,
+  reason: string,
+): Promise<void> {
+  try {
+    const entryPath = outboxEntryPath(outboxDir, id);
+    const failedPath = deadLetterPath(outboxDir, id);
+    if (existsSync(entryPath)) {
+      const content = await fs.readFile(entryPath, "utf8");
+      await atomicallyWrite(
+        failedPath,
+        JSON.stringify({ ...JSON.parse(content), deadLetteredWith: reason }),
+      );
+      await fs.rm(entryPath, { force: true });
+    }
+    logger.warn(`Event ${id} has been dead-lettered (${reason})`);
+  } catch (e) {
+    logger.error(e, `Failed to dead-letter event ${id}`);
+  }
+}
+
+/**
+ * Attempts delivery of every pending outbox entry (skipping those scheduled
+ * for a later retry) and cleans up / dead-letters them as appropriate.
+ * Called at startup and after each scan so events survive restarts.
+ */
+export async function flushOutbox(
+  webhookConfig: WebhookConfig,
+): Promise<void> {
+  let entries: string[];
+  try {
+    await fs.mkdir(webhookConfig.outboxDir, { recursive: true });
+    entries = await fs.readdir(webhookConfig.outboxDir);
+  } catch (e) {
+    logger.error(e, "Failed to list outbox directory");
+    return;
+  }
+
+  const now = Date.now();
+  for (const fileName of entries) {
+    if (!fileName.endsWith(".json") || fileName.endsWith(".failed.json")) {
+      continue;
+    }
+    const filePath = path.join(webhookConfig.outboxDir, fileName);
+    const entry = await readOutboxEntry(filePath);
+    if (entry === null) {
+      continue;
+    }
+    if (Date.parse(entry.nextAttemptAt) > now) {
+      continue;
+    }
+
+    const outcome = await deliverEvent(webhookConfig, entry);
+    if (outcome === "success") {
+      await removeOutboxEntry(webhookConfig.outboxDir, entry.id);
+      continue;
+    }
+    if (outcome === "dead-letter") {
+      await deadLetterEntry(
+        webhookConfig.outboxDir,
+        entry.id,
+        "permanent rejection",
+      );
+      continue;
+    }
+
+    entry.attempts += 1;
+    if (entry.attempts >= webhookConfig.maxAttempts) {
+      await deadLetterEntry(
+        webhookConfig.outboxDir,
+        entry.id,
+        `too many attempts (${entry.attempts})`,
+      );
+      continue;
+    }
+    entry.nextAttemptAt = new Date(
+      now + entry.attempts * 30_000,
+    ).toISOString();
+    await atomicallyWrite(filePath, JSON.stringify(entry));
+  }
 }
 
 /**
@@ -260,5 +443,10 @@ export async function sendScanEvent(
     files: fileDescriptors,
   };
 
-  await deliverBestEffort(webhookConfig, events);
+  if (webhookConfig.durableOutbox) {
+    await enqueueEvent(webhookConfig, events);
+    await flushOutbox(webhookConfig);
+  } else {
+    await deliverBestEffort(webhookConfig, events);
+  }
 }

--- a/test/postProcessing.test.ts
+++ b/test/postProcessing.test.ts
@@ -168,6 +168,67 @@ describe("postProcessing", () => {
       expect(remaining).to.deep.equal([]);
     });
 
+    it("keeps going when the webhook outbox write fails", async () => {
+      scanConfig.paperlessConfig = paperlessConfig();
+      mockPaperlessSuccess();
+      scanJobContent.meta = {
+        command: "listen",
+        scanCount: 1,
+        device: { ip: "127.0.0.1", isEscl: false },
+        target: undefined,
+        settings: {
+          inputSource: InputSource.Adf,
+          contentType: "Document",
+          format: "pdf",
+          sourceFormat: "jpg",
+          mode: ScanMode.Color,
+          colorDepth: 8,
+          channels: 3,
+          resolution: 200,
+          isDuplex: false,
+          pageCountingStrategy: PageCountingStrategy.Normal,
+          paperSize: undefined,
+          paperDim: undefined,
+        },
+        startedAt: new Date().toISOString(),
+        instance: { id: "test", startedAt: new Date().toISOString() },
+      };
+      // outboxDir points at a regular file: writing an entry fails (ENOTDIR).
+      const blockingFile = path.join(tempFolder, "blocker");
+      await fs.writeFile(blockingFile, "not a directory");
+      try {
+        scanConfig.webhookConfig = {
+          url: "http://webhook.example.test",
+          auth: "none",
+          authHeader: "x-webhook-signature",
+          outboxDir: blockingFile,
+          maxAttempts: 5,
+          durableOutbox: true,
+          keepFiles: false,
+        };
+
+        const result = await postProcessing(
+          scanConfig,
+          tempFolder,
+          tempFolder,
+          1,
+          scanJobContent,
+          new Date(),
+          true,
+        );
+
+        expect(result.uploadSucceeded).to.equal(true);
+        // The pdf is still cleaned up despite the webhook failure.
+        const remaining = (await fs.readdir(tempFolder)).filter((f) =>
+          f.endsWith(".pdf"),
+        );
+        expect(remaining).to.deep.equal([]);
+      } finally {
+        await fs.rm(blockingFile, { force: true });
+        scanConfig.webhookConfig = undefined;
+      }
+    });
+
     it("reports the failure and keeps the pdf when paperless rejects the upload", async () => {
       scanConfig.paperlessConfig = paperlessConfig();
       nock("http://paperless.example.test")
@@ -231,7 +292,9 @@ describe("postProcessing", () => {
       expect(existsSync(filePath)).to.equal(false);
     });
 
-    it("keeps going when the webhook cannot read the scan file", async () => {
+    it("keeps going when the webhook outbox write fails", async () => {
+      scanConfig.paperlessConfig = paperlessConfig();
+      mockPaperlessSuccess();
       scanJobContent.meta = {
         command: "listen",
         scanCount: 1,
@@ -239,8 +302,8 @@ describe("postProcessing", () => {
         target: undefined,
         settings: {
           inputSource: InputSource.Adf,
-          contentType: "Photo",
-          format: "jpg",
+          contentType: "Document",
+          format: "pdf",
           sourceFormat: "jpg",
           mode: ScanMode.Color,
           colorDepth: 8,
@@ -254,40 +317,40 @@ describe("postProcessing", () => {
         startedAt: new Date().toISOString(),
         instance: { id: "test", startedAt: new Date().toISOString() },
       };
-      // The element path does not exist: sendScanEvent throws while reading
-      // it. The scan itself must still complete (nothing was delivered).
-      scanJobContent = {
-        elements: [
-          {
-            pageNumber: 1,
-            path: path.join(tempFolder, "missing.jpg"),
-            width: 100,
-            height: 100,
-            xResolution: 96,
-            yResolution: 96,
-          },
-        ],
-        meta: scanJobContent.meta,
-      };
-      scanConfig.webhookConfig = {
-        url: "http://webhook.example.test",
-        auth: "none",
-        authHeader: "x-webhook-signature",
-        keepFiles: false,
-      };
+      // outboxDir points at a regular file: writing an entry fails (ENOTDIR).
+      const blockingFile = path.join(tempFolder, "blocker");
+      await fs.writeFile(blockingFile, "not a directory");
+      try {
+        scanConfig.webhookConfig = {
+          url: "http://webhook.example.test",
+          auth: "none",
+          authHeader: "x-webhook-signature",
+          outboxDir: blockingFile,
+          maxAttempts: 5,
+          durableOutbox: true,
+          keepFiles: false,
+        };
 
-      const result = await postProcessing(
-        scanConfig,
-        tempFolder,
-        tempFolder,
-        1,
-        scanJobContent,
-        new Date(),
-        false,
-      );
+        const result = await postProcessing(
+          scanConfig,
+          tempFolder,
+          tempFolder,
+          1,
+          scanJobContent,
+          new Date(),
+          true,
+        );
 
-      expect(result.uploadSucceeded).to.equal(true);
-      scanConfig.webhookConfig = undefined;
+        expect(result.uploadSucceeded).to.equal(true);
+        // The pdf is still cleaned up despite the webhook failure.
+        const remaining = (await fs.readdir(tempFolder)).filter((f) =>
+          f.endsWith(".pdf"),
+        );
+        expect(remaining).to.deep.equal([]);
+      } finally {
+        await fs.rm(blockingFile, { force: true });
+        scanConfig.webhookConfig = undefined;
+      }
     });
 
     it("groups multi-page scans into a single pdf for paperless", async () => {

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -7,7 +7,7 @@ import os from "node:os";
 import path from "node:path";
 import fsPromises from "node:fs/promises";
 import { createHash, createHmac } from "node:crypto";
-import { sendScanEvent } from "../src/webhook/webhook.js";
+import { flushOutbox, sendScanEvent } from "../src/webhook/webhook.js";
 import type { WebhookConfig } from "../src/webhook/WebhookConfig.js";
 import type { ScanContent } from "../src/type/ScanContent.js";
 import type { ScanMetadata } from "../src/type/ScanMetadata.js";
@@ -105,6 +105,9 @@ describe("webhook", () => {
       url: "http://127.0.0.1:1",
       auth: "none",
       authHeader: "x-webhook-signature",
+      outboxDir: tempDir,
+      maxAttempts: 5,
+      durableOutbox: true,
       keepFiles: false,
     };
     scanContent = { elements: [], meta: buildMetadata() };
@@ -118,7 +121,7 @@ describe("webhook", () => {
   });
 
   describe("sendScanEvent", () => {
-    it("delivers the event and does not persist anything", async () => {
+    it("delivers the event and removes the outbox entry", async () => {
       const srv = await startServer([200]);
       config.url = `http://127.0.0.1:${srv.port}`;
 
@@ -199,7 +202,7 @@ describe("webhook", () => {
       expect(payload.pages[0]).to.not.have.property("path");
     });
 
-    it("does not follow a redirect from the endpoint (3xx)", async () => {
+    it("keeps the event in the outbox when the endpoint redirects (3xx)", async () => {
       let finalHit = false;
       const server = http.createServer((req, res) => {
         if (req.url === "/start") {
@@ -218,16 +221,34 @@ describe("webhook", () => {
 
       await sendScanEvent(scanContent, [{ path: filePath }], [], config);
 
-      // The 301 must not be followed as an empty GET that would acknowledge
-      // the event without its payload.
       expect(finalHit).to.equal(false);
+      const remaining = await fsPromises.readdir(tempDir);
+      expect(remaining.filter((f) => f.endsWith(".json"))).to.have.length(1);
     });
 
-    it("sends once and persists nothing on failure", async () => {
+    it("writes outbox entries with restrictive permissions (0600)", async () => {
       const srv = await startServer([500]);
       config.url = `http://127.0.0.1:${srv.port}`;
 
       await sendScanEvent(scanContent, [{ path: filePath }], [], config);
+
+      const entries = (await fsPromises.readdir(tempDir)).filter((f) =>
+        f.endsWith(".json"),
+      );
+      expect(entries).to.have.length(1);
+      const stat = await fsPromises.stat(path.join(tempDir, entries[0]));
+      expect(stat.mode & 0o777).to.equal(0o600);
+    });
+
+    it("best-effort mode sends once and persists nothing on failure", async () => {
+      const srv = await startServer([500]);
+      const simpleConfig: WebhookConfig = {
+        ...config,
+        url: `http://127.0.0.1:${srv.port}`,
+        durableOutbox: false,
+      };
+
+      await sendScanEvent(scanContent, [{ path: filePath }], [], simpleConfig);
 
       expect(srv.requests).to.have.length(1);
       const remaining = await fsPromises.readdir(tempDir);
@@ -424,4 +445,146 @@ describe("webhook", () => {
     });
   });
 
+  describe("retry and idempotency", () => {
+    it("keeps the entry after a 5xx and delivers on a later flush with the same id", async () => {
+      const srv = await startServer([500, 200]);
+      config.url = `http://127.0.0.1:${srv.port}`;
+
+      await sendScanEvent(scanContent, [{ path: filePath }], [], config);
+
+      let files = await fsPromises.readdir(tempDir);
+      const pending = files.find((f) => f.endsWith(".json"));
+      expect(pending).to.not.be.undefined;
+      expect(files.some((f) => f.endsWith(".failed.json"))).to.be.false;
+
+      // Re-schedule the retry as a later boot would, then flush again.
+      const entryPath = path.join(tempDir, pending!);
+      const entry = JSON.parse(await fsPromises.readFile(entryPath, "utf8")) as {
+        id: string;
+        attempts: number;
+        nextAttemptAt: string;
+      };
+      expect(entry.attempts).to.equal(1);
+      entry.nextAttemptAt = new Date(Date.now() - 1000).toISOString();
+      await fsPromises.writeFile(entryPath, JSON.stringify(entry), "utf8");
+
+      await flushOutbox(config);
+
+      expect(srv.requests).to.have.length(2);
+      expect(srv.requests[0].headers["idempotency-key"]).to.equal(
+        srv.requests[1].headers["idempotency-key"],
+      );
+      files = await fsPromises.readdir(tempDir);
+      expect(files.filter((f) => f.endsWith(".json"))).to.deep.equal([]);
+    });
+
+    it("dead-letters on a 4xx response", async () => {
+      const srv = await startServer([400]);
+      config.url = `http://127.0.0.1:${srv.port}`;
+
+      await sendScanEvent(scanContent, [{ path: filePath }], [], config);
+
+      const files = await fsPromises.readdir(tempDir);
+      expect(files.some((f) => f.endsWith(".failed.json"))).to.be.true;
+      expect(files.some((f) => f.endsWith(".json") && !f.endsWith(".failed.json"))).to.be
+        .false;
+    });
+
+    it("retries on 429 instead of dead-lettering", async () => {
+      const srv = await startServer([429, 200]);
+      config.url = `http://127.0.0.1:${srv.port}`;
+
+      await sendScanEvent(scanContent, [{ path: filePath }], [], config);
+
+      let files = await fsPromises.readdir(tempDir);
+      expect(files.some((f) => f.endsWith(".json") && !f.endsWith(".failed.json")))
+        .to.be.true;
+      expect(files.some((f) => f.endsWith(".failed.json"))).to.be.false;
+
+      const entryFile = files.find(
+        (f) => f.endsWith(".json") && !f.endsWith(".failed.json"),
+      )!;
+      const entry = JSON.parse(
+        await fsPromises.readFile(path.join(tempDir, entryFile), "utf8"),
+      ) as { nextAttemptAt: string };
+      entry.nextAttemptAt = new Date(Date.now() - 1000).toISOString();
+      await fsPromises.writeFile(
+        path.join(tempDir, entryFile),
+        JSON.stringify(entry),
+        "utf8",
+      );
+
+      await flushOutbox(config);
+
+      expect(srv.requests).to.have.length(2);
+      files = await fsPromises.readdir(tempDir);
+      expect(files.filter((f) => f.endsWith(".json"))).to.deep.equal([]);
+    });
+
+    it("dead-letters after max attempts", async () => {
+      config.maxAttempts = 2;
+      const srv = await startServer([500, 500]);
+      const cfg = { ...config, url: `http://127.0.0.1:${srv.port}` };
+
+      await sendScanEvent(scanContent, [{ path: filePath }], [], cfg);
+
+      let pending = await fsPromises.readdir(tempDir);
+      const entryFile = pending.find(
+        (f) => f.endsWith(".json") && !f.endsWith(".failed.json"),
+      );
+      expect(entryFile).to.not.be.undefined;
+
+      const entryPath = path.join(tempDir, entryFile!);
+      const entry = JSON.parse(await fsPromises.readFile(entryPath, "utf8")) as {
+        nextAttemptAt: string;
+      };
+      entry.nextAttemptAt = new Date(Date.now() - 1000).toISOString();
+      await fsPromises.writeFile(entryPath, JSON.stringify(entry), "utf8");
+
+      await flushOutbox(cfg);
+
+      pending = await fsPromises.readdir(tempDir);
+      expect(pending.some((f) => f.endsWith(".failed.json"))).to.be.true;
+      expect(
+        pending.some((f) => f.endsWith(".json") && !f.endsWith(".failed.json")),
+      ).to.be.false;
+    });
+  });
+
+  describe("restart survival", () => {
+    it("keeps a pending entry across processes and flushes it on the next boot", async () => {
+      // First process: the webhook is unreachable, the event stays pending with a
+      // future retry.
+      config.url = "http://127.0.0.1:1";
+      await sendScanEvent(scanContent, [{ path: filePath }], [], config);
+
+      const files = await fsPromises.readdir(tempDir);
+      expect(
+        files.some((f) => f.endsWith(".json") && !f.endsWith(".failed.json")),
+      ).to.be.true;
+
+      // Time passes: the retry becomes due before the "next boot".
+      const pendingFile = files.find(
+        (f) => f.endsWith(".json") && !f.endsWith(".failed.json"),
+      )!;
+      const entry = JSON.parse(
+        await fsPromises.readFile(path.join(tempDir, pendingFile), "utf8"),
+      ) as { nextAttemptAt: string };
+      entry.nextAttemptAt = new Date(Date.now() - 1000).toISOString();
+      await fsPromises.writeFile(
+        path.join(tempDir, pendingFile),
+        JSON.stringify(entry),
+        "utf8",
+      );
+
+      // "Restart": a new process boots, webhook is now reachable, flushes.
+      const srv = await startServer([200]);
+      const restarted = { ...config, url: `http://127.0.0.1:${srv.port}` };
+      await flushOutbox(restarted);
+
+      expect(srv.requests).to.have.length(1);
+      const after = await fsPromises.readdir(tempDir);
+      expect(after.filter((f) => f.endsWith(".json"))).to.deep.equal([]);
+    });
+  });
 });


### PR DESCRIPTION
## Problem

The base webhook PR delivers events best-effort: a single POST, and a briefly unreachable receiver (n8n down, 429, timeout) loses the event.

## Solution

An **opt-in durable outbox** behind `--webhook-durable-outbox` / `webhook_durable_outbox` / `WEBHOOK_DURABLE_OUTBOX` (default: off, keeping the simple best-effort path):
- Events are written to the outbox (atomic write, mode `0600`) before delivery.
- Retried at startup and after each scan with backoff on 408/429/5xx and redirects.
- Permanent 4xx dead-lettered to `<id>.failed.json` instead of being lost.
- Pending events survive restarts (same idempotency-key on retries).
- The HTTP POST is shared with the best-effort path (`sendEventOnce`).

Stacked on the webhook PR (`split/webhook-outbox`): merge that one first, then this one.

## Review checklist

Already fixed (verify):
- [x] Redirects are never followed: a 301/302 would downgrade the POST to an empty GET and acknowledge a lost event (`maxRedirects: 0`, 3xx → retry).

Outbox reliability:
- [ ] Retried outbox entries reference a deleted local `path` when `keepFiles: false` — mark it unavailable (`path: null`).
- [ ] Dead-letter files accumulate and a corrupt entry re-logs forever — add TTL cleanup and quarantine.
- [ ] Outbox delivery order is not guaranteed across retries — sort by creation time and document.
- [ ] No atomic claim on outbox entries — two processes sharing the dir can double-deliver.
- [ ] Every scan re-attempts the whole backlog (O(N)) — cap attempts per flush or move the flush off the scan path.
- [ ] The 10s HTTP timeout is not configurable — slow-but-working receivers get dead-lettered.
- [ ] No SIGTERM/SIGINT handling — add graceful shutdown and `.tmp` cleanup.

## Testing

- `test/webhook.test.ts` (outbox suite): retry with the same idempotency key, 4xx dead-letter, 429/5xx retry, max-attempts cap, restart survival, mode `0600`, redirect handling.
- Full suite green (`704 passing`).